### PR TITLE
Prevent area copy exploit with CanTool hook check

### DIFF
--- a/lua/weapons/gmod_tool/stools/advdupe2.lua
+++ b/lua/weapons/gmod_tool/stools/advdupe2.lua
@@ -51,7 +51,10 @@ if(SERVER)then
 						EntTable[ent:EntIndex()] = ent
 					end
 				else
-					EntTable[ent:EntIndex()] = ent
+					local tr = { Entity = ent }
+					if ( hook.Run( "CanTool", ply, tr, "advdupe2" ) ) then
+						EntTable[ent:EntIndex()] = ent
+					end
 				end
 			end
 		end


### PR DESCRIPTION
If CPPI is not detected, this will default to running the CanTool hook, effectively preventing the Area Copy exploit for any servers that have prop protection addons that use CanTool.

I've grown tired of having to patch this myself. I wish CPPI wasn't used at all, and that the base/sandbox hooks could get called instead (like Wiremod has been moving toward the last year or so).

I have tested this and it appears to work fine. I encourage you to test it yourself, or even consider switching from CPPI to the base/sandbox hooks altogether.
