### PR TITLE
Fixed #31 and #38.

### DIFF
--- a/lua/weapons/gmod_tool/stools/advdupe2.lua
+++ b/lua/weapons/gmod_tool/stools/advdupe2.lua
@@ -164,6 +164,11 @@ if(SERVER)then
 				end
 				return false 
 			end
+			
+			-- Filter duplicator blocked entities out.
+			if trace.Entity.DoNotDuplicate then
+				return false
+			end
 
 			//If Alt is being held, add a prop to the dupe
 			if(self:GetStage()==0 and ply:KeyDown(IN_WALK) and ply.AdvDupe2.Entities~=nil and table.Count(ply.AdvDupe2.Entities)>0)then 


### PR DESCRIPTION
Fixed #31 and #38.

So addon coders can define their entities and constraints to not to be
dupeable with `ent.DoNotDuplicate = true`.

This is analog to: https://github.com/wiremod/advduplicator/pull/67