### PR TITLE
Correctly handle upload failures.

### DIFF
--- a/lua/advdupe2/cl_networking.lua
+++ b/lua/advdupe2/cl_networking.lua
@@ -266,7 +266,7 @@ local function SendFileToServer(eof)
 	local data = string.sub(AdvDupe2.File, AdvDupe2.LastPos, AdvDupe2.LastPos+eof)
 
 	AdvDupe2.LastPos = AdvDupe2.LastPos+eof+1
-	AdvDupe2.ProgressBar.Percent = math.floor((AdvDupe2.LastPos/AdvDupe2.Length)*100)
+	AdvDupe2.ProgressBar.Percent = math.min(math.floor((AdvDupe2.LastPos/AdvDupe2.Length)*100),100)
 
 	net.Start("AdvDupe2_ReceiveFile")
 		net.WriteBit(AdvDupe2.LastPos>=AdvDupe2.Length)

--- a/lua/advdupe2/cl_networking.lua
+++ b/lua/advdupe2/cl_networking.lua
@@ -267,15 +267,9 @@ local function SendFileToServer(eof)
 
 	AdvDupe2.LastPos = AdvDupe2.LastPos+eof+1
 	AdvDupe2.ProgressBar.Percent = math.floor((AdvDupe2.LastPos/AdvDupe2.Length)*100)
-	local status = false
-	if(AdvDupe2.LastPos>=AdvDupe2.Length)then
-		status=true
-		uploading = false
-		AdvDupe2.RemoveProgressBar()
-	end
 
 	net.Start("AdvDupe2_ReceiveFile")
-		net.WriteBit(status)
+		net.WriteBit(AdvDupe2.LastPos>=AdvDupe2.Length)
 		net.WriteString(data)
 	net.SendToServer()
 	

--- a/lua/advdupe2/cl_networking.lua
+++ b/lua/advdupe2/cl_networking.lua
@@ -293,7 +293,9 @@ usermessage.Hook("AdvDupe2_ReceiveNextStep",function(um)
 		AdvDupe2.InitProgressBar("Opening:")
 	end
 	
-	SendFileToServer(um:ReadShort())
+	if uploading then
+		SendFileToServer(um:ReadShort())
+	end
 end)
 
 usermessage.Hook("AdvDupe2_UploadRejected",function(um)

--- a/lua/advdupe2/cl_networking.lua
+++ b/lua/advdupe2/cl_networking.lua
@@ -240,20 +240,15 @@ function AdvDupe2.InitializeUpload(ReadPath, ReadArea)
 	
 	uploading = true
 	
-	AdvDupe2.Decode(read, function(success,dupe,info,moreinfo) 
-								if(success)then 
-									AdvDupe2.LoadGhosts(dupe, info, moreinfo, name)
-									
-									AdvDupe2.File = AdvDupe2.Null.esc(read)
-									AdvDupe2.LastPos = 0
-									AdvDupe2.Length = string.len(AdvDupe2.File)
-									AdvDupe2.InitProgressBar("Opening:")
-									RunConsoleCommand("AdvDupe2_InitReceiveFile")
-								else
-									uploading = false
-									AdvDupe2.Notify("File could not be decoded. Upload Canceled.", NOTIFY_ERROR)
-								end 
-						  end)
+	AdvDupe2.Decode(read, function(success, dupe, info, moreinfo) 
+		if(success)then
+			AdvDupe2.PendingDupe = { read, dupe, info, moreinfo, name }
+			RunConsoleCommand("AdvDupe2_InitReceiveFile")
+		else
+			uploading = false
+			AdvDupe2.Notify("File could not be decoded. Upload Canceled.", NOTIFY_ERROR)
+		end 
+	end)
 end
 
 --[[
@@ -287,14 +282,28 @@ local function SendFileToServer(eof)
 end
 
 usermessage.Hook("AdvDupe2_ReceiveNextStep",function(um)
+	if AdvDupe2.PendingDupe then
+		local read,dupe,info,moreinfo,name = unpack( AdvDupe2.PendingDupe )
+		
+		AdvDupe2.PendingDupe = nil
+		AdvDupe2.LoadGhosts(dupe, info, moreinfo, name )
+		AdvDupe2.File = AdvDupe2.Null.esc(read)
+		AdvDupe2.LastPos = 0
+		AdvDupe2.Length = string.len(AdvDupe2.File)
+		AdvDupe2.InitProgressBar("Opening:")
+	end
+	
 	SendFileToServer(um:ReadShort())
 end)
 
 usermessage.Hook("AdvDupe2_UploadRejected",function(um)
-	if(uploading)then return end
-	AdvDupe2.File = nil
-	AdvDupe2.LastPos = nil
-	AdvDupe2.Length = nil
+	if uploading then
+		uploading = false
+		AdvDupe2.PendingDupe = nil
+		AdvDupe2.File = nil
+		AdvDupe2.LastPos = nil
+		AdvDupe2.Length = nil
+	end
 	if(um:ReadBool())then AdvDupe2.RemoveProgressBar() end
 end)
 

--- a/lua/advdupe2/sv_networking.lua
+++ b/lua/advdupe2/sv_networking.lua
@@ -203,7 +203,8 @@ end
 ]]
 local function AdvDupe2_InitReceiveFile( ply, cmd, args )
 	if(not IsValid(ply))then return end
-
+	if(not ply.AdvDupe2)then ply.AdvDupe2={} end
+	
 	if(ply.AdvDupe2.Pasting or ply.AdvDupe2.Downloading)then
 		umsg.Start("AdvDupe2_UploadRejected", ply)
 			umsg.Bool(false)

--- a/lua/advdupe2/sv_networking.lua
+++ b/lua/advdupe2/sv_networking.lua
@@ -205,7 +205,8 @@ local function AdvDupe2_InitReceiveFile( ply, cmd, args )
 	if(not IsValid(ply))then return end
 	if(not ply.AdvDupe2)then ply.AdvDupe2={} end
 	
-	if(ply.AdvDupe2.Pasting or ply.AdvDupe2.Downloading)then
+	local id = ply:UniqueID()
+	if(ply.AdvDupe2.Pasting or ply.AdvDupe2.Downloading or AdvDupe2.Network.ClientNetworks[id])then
 		umsg.Start("AdvDupe2_UploadRejected", ply)
 			umsg.Bool(false)
 		umsg.End()
@@ -213,8 +214,6 @@ local function AdvDupe2_InitReceiveFile( ply, cmd, args )
 		return
 	end
 	
-	local id = ply:UniqueID()
-	if(AdvDupe2.Network.ClientNetworks[id])then return false end
 	ply.AdvDupe2.Downloading = true
 	ply.AdvDupe2.Uploading = true
 	//ply.AdvDupe2.Name = args[1]

--- a/lua/advdupe2/sv_networking.lua
+++ b/lua/advdupe2/sv_networking.lua
@@ -272,7 +272,7 @@ local function AdvDupe2_ReceiveFile(len, ply, len2)
 		ply.AdvDupe2.Uploading = false
 		
 		umsg.Start("AdvDupe2_UploadRejected", ply)
-			umsg.Bool(true)
+			umsg.Bool(false)
 		umsg.End()
 		AdvDupe2.Notify(ply,"Upload Rejected!",NOTIFY_GENERIC,5)
 		return
@@ -288,7 +288,7 @@ local function AdvDupe2_ReceiveFile(len, ply, len2)
 		ply.AdvDupe2.Uploading = false
 					
 		umsg.Start("AdvDupe2_UploadRejected", ply)
-			umsg.Bool(false)
+			umsg.Bool(true)
 		umsg.End()
 		return
 	end


### PR DESCRIPTION
Before, when trying to upload a file while pasting, the server would send a AdvDupe2_UploadRejected, but the client wouldn't cancel the upload (for whatever reason). I also made it so that the ghosts don't load until the server confirms that it is okay to upload.