### PR TITLE
Make paste angles default to 0,0,0

### DIFF
--- a/lua/weapons/gmod_tool/stools/advdupe2.lua
+++ b/lua/weapons/gmod_tool/stools/advdupe2.lua
@@ -84,12 +84,7 @@ if(SERVER)then
 		
 		local z = math.Clamp((tonumber(ply:GetInfo("advdupe2_offset_z")) + ply.AdvDupe2.HeadEnt.Z), -16000, 16000)
 		ply.AdvDupe2.Position = trace.HitPos + Vector(0, 0, z)
-		
-		local pitch = tonumber(ply:GetInfo("advdupe2_offset_pitch")) or 0
-		local yaw   = tonumber(ply:GetInfo("advdupe2_offset_yaw"))   or 0
-		local roll  = tonumber(ply:GetInfo("advdupe2_offset_roll"))  or 0
-		ply.AdvDupe2.Angle = Angle(pitch, yaw, roll)
-		
+		ply.AdvDupe2.Angle = Angle(ply:GetInfoNum("advdupe2_offset_pitch", 0), ply:GetInfoNum("advdupe2_offset_yaw", 0), ply:GetInfoNum("advdupe2_offset_roll", 0))
 		if(tobool(ply:GetInfo("advdupe2_offset_world")))then ply.AdvDupe2.Angle = ply.AdvDupe2.Angle - ply.AdvDupe2.Entities[ply.AdvDupe2.HeadEnt.Index].PhysicsObjects[0].Angle end
 		
 		ply.AdvDupe2.Pasting = true

--- a/lua/weapons/gmod_tool/stools/advdupe2.lua
+++ b/lua/weapons/gmod_tool/stools/advdupe2.lua
@@ -84,7 +84,12 @@ if(SERVER)then
 		
 		local z = math.Clamp((tonumber(ply:GetInfo("advdupe2_offset_z")) + ply.AdvDupe2.HeadEnt.Z), -16000, 16000)
 		ply.AdvDupe2.Position = trace.HitPos + Vector(0, 0, z)
-		ply.AdvDupe2.Angle = Angle(tonumber(ply:GetInfo("advdupe2_offset_pitch")), tonumber(ply:GetInfo("advdupe2_offset_yaw")), tonumber(ply:GetInfo("advdupe2_offset_roll")))
+		
+		local pitch = tonumber(ply:GetInfo("advdupe2_offset_pitch")) or 0
+		local yaw   = tonumber(ply:GetInfo("advdupe2_offset_yaw"))   or 0
+		local roll  = tonumber(ply:GetInfo("advdupe2_offset_roll"))  or 0
+		ply.AdvDupe2.Angle = Angle(pitch, yaw, roll)
+		
 		if(tobool(ply:GetInfo("advdupe2_offset_world")))then ply.AdvDupe2.Angle = ply.AdvDupe2.Angle - ply.AdvDupe2.Entities[ply.AdvDupe2.HeadEnt.Index].PhysicsObjects[0].Angle end
 		
 		ply.AdvDupe2.Pasting = true


### PR DESCRIPTION
Serverside:
```
[ERROR] addons/tool_advdupe2/lua/weapons/gmod_tool/stools/advdupe2.lua:87: bad argument #3 to 'Angle' (number expected, got nil)
  1. Angle - [C]:-1
   2. LeftClick - addons/tool_advdupe2/lua/weapons/gmod_tool/stools/advdupe2.lua:87
    3. unknown - gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua:227
```

This was caused by a client, so I can't give exact details on what they did to make this occur.

```ply:GetInfo("advdupe2_offset_roll")``` somehow returned ```nil```, and since ```tonumber``` returns ```nil``` when given ```nil```, the error occurred.

Defaulting the numbers to 0 before creating the angle should be fine. It doesn't tackle the many other places where GetInfo is currently free to error in similar circumstances, but this is the only one I've noticed so far.

This is the change:

```lua
ply.AdvDupe2.Angle = Angle(ply:GetInfoNum("advdupe2_offset_pitch", 0), ply:GetInfoNum("advdupe2_offset_yaw", 0), ply:GetInfoNum("advdupe2_offset_roll", 0))
```