### PR TITLE
Prevent errors/lag exploits. Occurs if a player hasn't right clicked with the tool yet.

### DIFF
--- a/lua/weapons/gmod_tool/stools/advdupe2.lua
+++ b/lua/weapons/gmod_tool/stools/advdupe2.lua
@@ -691,6 +691,9 @@ if(SERVER)then
 	
 		local desc = net.ReadString()
 		local ent = net.ReadInt(16)
+
+		ply.AdvDupe2 = ply.AdvDupe2 or {}
+
 		if(ent~=0)then
 			ply.AdvDupe2.AutoSaveEnt = ent
 			if(ply:GetInfo("advdupe2_auto_save_contraption")=="1")then


### PR DESCRIPTION
To test, run this code once you join a server without equipping or using the advanced duplicator 2 tool.
`
for i = 1, 5000 do
	net.Start("AdvDupe2_CanAutoSave")
	net.SendToServer()
end
`