### PR TITLE
Fixed bug where duplicating effects would run PlayerSpawnSENT hook

### DIFF
--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -910,7 +910,7 @@ local function CreateEntityFromTable(EntTable, Player)
 			//Create sents using their spawn function with the arguments we stored earlier
 			sent = true
 
-			if(not EntTable.BuildDupeInfo.IsVehicle and not EntTable.BuildDupeInfo.IsNPC and EntTable.Class~="prop_ragdoll")then	//These three are auto done
+			if(not EntTable.BuildDupeInfo.IsVehicle and not EntTable.BuildDupeInfo.IsNPC and EntTable.Class ~= "prop_ragdoll" and EntTable.Class ~= "prop_effect") then	//These four are auto done
 				sent = hook.Call("PlayerSpawnSENT", nil, Player, EntTable.Class)
 			end
 


### PR DESCRIPTION
I noticed that the PlayerSpawnSENT hook is called when duplicating effects, this should not happen. What happens is that the PlayerSpawnSENT hook is called, then the PlayerSpawnEffect is called. So I added a check that prevents this from happening. 

I printed out the hook calls, and this is the output of duplicating an effect before and after the fix.

Before this fix:
```
playerSpawnSENT(Player [1][Weol], prop_effect)
playerSpawnEffect(Player [1][Weol], models/effects/splode.mdl)
playerSpawnedEffect(Player [1][Weol], models/effects/splode.mdl, Entity [114][prop_effect])
```

After this fix:
```
canTool(Player [1][Weol], table: 0x2f30bca0, advdupe2)
playerSpawnEffect(Player [1][Weol], models/effects/splode.mdl)
playerSpawnedEffect(Player [1][Weol], models/effects/splode.mdl, Entity [116][prop_effect])
```