### PR TITLE
Fix failure of contraption copy if GetChildren() returns NULL entities.

### DIFF
--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -112,11 +112,12 @@ local gtSetupTable = {
 }
 
 function AdvDupe2.duplicator.IsCopyable(Ent)
-	return not Ent.DoNotDuplicate and duplicator.IsAllowed(Ent:GetClass()) and IsValid(Ent:GetPhysicsObject())
+	return IsValid(Ent) and not Ent.DoNotDuplicate and duplicator.IsAllowed(Ent:GetClass()) and IsValid(Ent:GetPhysicsObject())
 end
 
 local function CopyEntTable(Ent, Offset)
 	-- Filter duplicator blocked entities out.
+	print(Ent)
 	if not AdvDupe2.duplicator.IsCopyable(Ent) then return nil end
 
 	local Tab = {}

--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -117,7 +117,6 @@ end
 
 local function CopyEntTable(Ent, Offset)
 	-- Filter duplicator blocked entities out.
-	print(Ent)
 	if not AdvDupe2.duplicator.IsCopyable(Ent) then return nil end
 
 	local Tab = {}

--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -112,7 +112,7 @@ local gtSetupTable = {
 }
 
 function AdvDupe2.duplicator.IsCopyable(Ent)
-	return IsValid(Ent) and not Ent.DoNotDuplicate and duplicator.IsAllowed(Ent:GetClass()) and IsValid(Ent:GetPhysicsObject())
+	return not Ent.DoNotDuplicate and duplicator.IsAllowed(Ent:GetClass()) and IsValid(Ent:GetPhysicsObject())
 end
 
 local function CopyEntTable(Ent, Offset)
@@ -429,7 +429,9 @@ local function Copy(Ent, EntTable, ConstraintTable, Offset)
 		local parent = Ent:GetParent()
 		if IsValid(parent) then Copy(parent, EntTable, ConstraintTable, Offset) end
 		for k, child in pairs(Ent:GetChildren()) do
-			Copy(child, EntTable, ConstraintTable, Offset)
+			if child:IsValid() then
+				Copy(child, EntTable, ConstraintTable, Offset)
+			end
 		end
 	end
 


### PR DESCRIPTION
For a long I've been having an issue where copying a contraption directly would fail with a Lua error, and have fallen back on performing world copies instead. I finally looked into the issue and discovered that GetChildren() can sometimes return NULL entities. 
Other areas where Copy() is applied to an entity first verify that the entity to be copied is valid. Only the section to copy children omitted this check. Adding this check successfully fixes the problem of being unable to directly dupe contraptions where GetChildren() returns NULL entities.