### PR TITLE
Make sure Constraints table exist

### DIFF
--- a/lua/advdupe2/sh_codec.lua
+++ b/lua/advdupe2/sh_codec.lua
@@ -423,6 +423,7 @@ end
 function AdvDupe2.CheckValidDupe(dupe, info)
 	if not dupe.HeadEnt then return false, "Missing HeadEnt table" end
 	if not dupe.Entities then return false, "Missing Entities table" end
+	if not dupe.Constraints then return false, "Missing Constraints table" end
 	if not dupe.HeadEnt.Z then return false, "Missing HeadEnt.Z" end
 	if not dupe.HeadEnt.Pos then return false, "Missing HeadEnt.Pos" end
 	if not dupe.HeadEnt.Index then return false, "Missing HeadEnt.Index" end

--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -1553,12 +1553,18 @@ local function RemoveSpawnedEntities(tbl, i)
 end
 
 function AdvDupe2.InitPastingQueue(Player, PositionOffset, AngleOffset, OrigPos, Constrs, Parenting, DisableParents, DisableProtection)
+    if not Player.AdvDupe2.Constraints then
+        Player.AdvDupe2.Constraints = {}
+    end
+
 	local i = #AdvDupe2.JobManager.Queue + 1
 	AdvDupe2.JobManager.Queue[i] = {}
+
 	local Queue = AdvDupe2.JobManager.Queue[i]
 	Queue.Player = Player
 	Queue.SortedEntities = {}
 	Queue.EntityList = table.Copy(Player.AdvDupe2.Entities)
+
 	if (Constrs) then
 		Queue.ConstraintList = table.Copy(Player.AdvDupe2.Constraints)
 	else

--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -1061,7 +1061,7 @@ local function CreateEntityFromTable(EntTable, Player)
 			for _, CreatedEntity in pairs(CreatedEntities) do
 				SafeRemoveEntity(CreatedEntity)
 			end
-            ErrorNoHaltWithStack(valid)
+			ErrorNoHaltWithStack(valid)
 		end
 
 		if (valid == false) then
@@ -1553,9 +1553,9 @@ local function RemoveSpawnedEntities(tbl, i)
 end
 
 function AdvDupe2.InitPastingQueue(Player, PositionOffset, AngleOffset, OrigPos, Constrs, Parenting, DisableParents, DisableProtection)
-    if not Player.AdvDupe2.Constraints then
-        Player.AdvDupe2.Constraints = {}
-    end
+	if not Player.AdvDupe2.Constraints then
+		Player.AdvDupe2.Constraints = {}
+	end
 
 	local i = #AdvDupe2.JobManager.Queue + 1
 	AdvDupe2.JobManager.Queue[i] = {}

--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -1553,10 +1553,6 @@ local function RemoveSpawnedEntities(tbl, i)
 end
 
 function AdvDupe2.InitPastingQueue(Player, PositionOffset, AngleOffset, OrigPos, Constrs, Parenting, DisableParents, DisableProtection)
-	if not Player.AdvDupe2.Constraints then
-		Player.AdvDupe2.Constraints = {}
-	end
-
 	local i = #AdvDupe2.JobManager.Queue + 1
 	AdvDupe2.JobManager.Queue[i] = {}
 


### PR DESCRIPTION
Currently if the constraints table does not exist (which a player can force) the serverside code will error and permanently stay stuck on pasting, preventing any other player from using advdupe2 until the initial paster leaves.