### PR TITLE
validation for entity args

### DIFF
--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -978,7 +978,11 @@ local function CreateEntityFromTable(EntTable, Player)
 			ArgList[iNumber] = Arg
 
 		end
-
+		
+		if #EntityClass.Args > #ArgList then
+			return
+		end
+		
 		-- Create and return the entity
 		if (EntTable.Class == "prop_physics") then
 			valid = MakeProp(Player, unpack(ArgList, 1, #EntityClass.Args)) -- Create prop_physics like this because if the model doesn't exist it will cause


### PR DESCRIPTION
Prior to this PR, clients could supply insufficient args when spawning an entity which will result in an error. https://github.com/wiremod/advdupe2/pull/417 mitigates this issue by deleting the bugged entities after they're spawned. However, this will still spam the server console with errors which can cause lag and be very annoying. This should properly fix the issue by preventing the bugged entities from being spawned in the first place.