### PR TITLE
New `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,34 @@
-# Advanced Duplicator 2
+# Advanced Duplicator 2 [![License](https://img.shields.io/github/license/wiremod/advdupe2?color=red)](LICENSE) [![Discord](https://img.shields.io/discord/231131817640460288?label=Discord&logo=discord&logoColor=ffffff&labelColor=7289DA&color=2c2f33)](https://discord.gg/H8UKY3Y) [![Workshop](https://img.shields.io/steam/subscriptions/773402917?logo=steam)](https://steamcommunity.com/sharedfiles/filedetails/?id=773402917)
 
-[Advanced Duplicator 2][ref-dupe2] is a [Garry's Mod][ref-gmod] addon which implements a tool similar to the [Duplicator][ref-dporg], but with many added features. It is a fork of (and not a direct successor to, despite the name) [Advanced Duplicator][ref-dupe1].
+> An addon for [Garry's Mod](https://garrysmod.com) which implements a tool similar to the [Duplicator](https://gmod.fandom.com/wiki/Duplicator), but with many added features. It is a fork of the [Advanced Duplicator](https://github.com/wiremod/advduplicator).
 
-# Workshop Installation
+## ⬇️ Installation
 
-The Wiremod Collection is available on the Steam Workshop! Go to the [Workshop page][ref-wirecoll] and press `Subscribe` on the addons you want
+| Addon | Workshop | GitHub |
+|  ---  |   ---    |   ---  |
+|**Wiremod**| [![Wiremod](https://img.shields.io/steam/subscriptions/160250458?logo=steam)](https://steamcommunity.com/sharedfiles/filedetails/?id=160250458) | https://github.com/wiremod/wire |
+|**AdvDupe2**| [![AdvDupe2](https://img.shields.io/steam/subscriptions/773402917?logo=steam)](https://steamcommunity.com/sharedfiles/filedetails/?id=773402917)| https://github.com/wiremod/advdupe2 |
+|**Wire Extras**| [None yet](https://github.com/wiremod/wire-extras/issues/113) | https://github.com/wiremod/wire-extras |
 
-# Manual Installation
+For git, inside of `steamapps/common/Garrysmod/garrysmod/addons`, run ``git clone https://github.com/wiremod/advdupe2``.
 
-Clone this repository into your `steamapps\common\GarrysMod\garrysmod\addons` folder using this command if you are using git:
+## 📖 Documentation
 
-    git clone https://github.com/wiremod/advdupe2.git advdupe2
+You can find documentation [on our wiki](https://github.com/wiremod/advdupe2/wiki)!
 
-# License
 
-Copyright 2014 onwards by the Wire Team
+## 🤝 Contributing
 
-Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+> Before contributing to wiremod, take a look at the [code of conduct](CODE_OF_CONDUCT.md).
 
-http://www.apache.org/licenses/LICENSE-2.0
+### 💡 Suggestions
 
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+To submit a suggestion, [use the discussions page](https://github.com/wiremod/advdupe2/discussions/new?category=suggestions).
 
-# Links
+### 🐛 Bug Reports
 
-[Garry's Mod](http://garrysmod.com/)
+To submit a bug report, [make an issue](https://github.com/wiremod/advdupe2/issues/new/choose).
 
-[WireTeam Workshop Collection][ref-wirecoll]
+### 🧑‍💻 Pull Requests
 
-[Wiremod landing page](http://wiremod.com)
-
-[Wiremod Official Discord](https://discord.gg/H8UKY3Y)
-
-# Contributor Guidelines
-
-See [CONTRIBUTING.md][ref-cont] for guidelines on contributing and participating in the wiremod project.
-
-[ref-gmod]: https://store.steampowered.com/app/4000/Garrys_Mod/
-[ref-dporg]: https://gmod.fandom.com/wiki/Duplicator
-[ref-dupe1]: https://steamcommunity.com/sharedfiles/filedetails/?id=163806212
-[ref-dupe2]: https://steamcommunity.com/sharedfiles/filedetails/?id=773402917
-[ref-wirecoll]: https://steamcommunity.com/id/wireteam/myworkshopfiles/?appid=4000
-[ref-cont]: https://github.com/wiremod/advdupe2/blob/master/CONTRIBUTING.md
+Before making a PR, ensure your code follows the [developer style guide](https://github.com/wiremod/wire/wiki/Developer-Style-Guide).


### PR DESCRIPTION
Parity with https://github.com/wiremod/wire/pull/2650

Pretty much the same. Just replaced wire references with advdupe2.

[Preview here](https://github.com/Vurv78/advdupe2/tree/new-readme)
