### PR TITLE
Fix language strings

### DIFF
--- a/lua/weapons/gmod_tool/stools/advdupe2.lua
+++ b/lua/weapons/gmod_tool/stools/advdupe2.lua
@@ -933,12 +933,12 @@ if(CLIENT)then
 
 	language.Add( "Tool.advdupe2.name",	"Advanced Duplicator 2" )
 	language.Add( "Tool.advdupe2.desc",	"Duplicate things." )
-	language.Add( "Tool.advdupe2.0",		"Primary: Paste, Secondary: Copy, Secondary+World: Select/Deselect All, Secondary+Shift: Area copy." )
-	language.Add( "Tool.advdupe2.1",		"Primary: Paste, Secondary: Copy an area, Reload: Autosave an area, Secondary+Shift: Cancel." )
-	language.Add( "Undone.AdvDupe2",	"Undone AdvDupe2 paste" )
-	language.Add( "Cleanup.AdvDupe2",	"Adv. Duplications" )
-	language.Add( "Cleaned.AdvDupe2",	"Cleaned up all Adv. Duplications" )
-	language.Add( "SBoxLimit.AdvDupe2",	"You've reached the Adv. Duplicator limit!" )
+	language.Add( "Tool.advdupe2.0",	"Primary: Paste, Secondary: Copy, Secondary+World: Select/Deselect All, Secondary+Shift: Area copy." )
+	language.Add( "Tool.advdupe2.1",	"Primary: Paste, Secondary: Copy an area, Reload: Autosave an area, Secondary+Shift: Cancel." )
+	language.Add( "Undone_AdvDupe2",	"Undone AdvDupe2 paste" )
+	language.Add( "Cleanup_AdvDupe2",	"AdvDupe2 Duplications" )
+	language.Add( "Cleaned_AdvDupe2",	"Cleaned up all AdvDupe2 Duplications" )
+	language.Add( "SBoxLimit_AdvDupe2",	"You've reached the AdvDupe2 Duplicator limit!" )
 
 	CreateClientConVar("advdupe2_offset_world", 0, false, true)
 	CreateClientConVar("advdupe2_offset_z", 0, false, true)


### PR DESCRIPTION
Self explanatory. Also updated the text to say "AdvDupe2" rather than "Adv. Duplicator"