### PR TITLE
Remove unneeded newline

### DIFF
--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -54,7 +54,7 @@ local function CopyClassArgTable(tab)
 					newtable[k] = v
 				end
 			else
-				print("[AdvDupe2] ClassArg table with key \"" .. tostring(k) .. "\" has unsupported value of type \"".. type(v) .."\"!\n")
+				print("[AdvDupe2] ClassArg table with key \"" .. tostring(k) .. "\" has unsupported value of type \"".. type(v) .."\"!")
 			end
 		end
 		return newtable


### PR DESCRIPTION
This print is already very spammy and the added newline doesn't help, print has a newline by itself so i don't see a reason why not.
Example:
![image](https://github.com/wiremod/advdupe2/assets/69946827/58c3c106-6638-4f6b-bbf7-9fa337638fbc)
