### PR TITLE
Hide classarg prints behind convar

### DIFF
--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -56,9 +56,9 @@ local function CopyClassArgTable(tab)
 					newtable[k] = v
 				end
 			else
-                if debugConvar:GetBool() then
-                    print("[AdvDupe2] ClassArg table with key \"" .. tostring(k) .. "\" has unsupported value of type \"".. type(v) .."\"!")
-                end
+				if debugConvar:GetBool() then
+					print("[AdvDupe2] ClassArg table with key \"" .. tostring(k) .. "\" has unsupported value of type \"".. type(v) .."\"!")
+				end
 			end
 		end
 		return newtable

--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -13,6 +13,8 @@ AdvDupe2.JobManager = {}
 AdvDupe2.JobManager.PastingHook = false
 AdvDupe2.JobManager.Queue = {}
 
+local debugConvar = GetConVar("AdvDupe2_DebugInfo")
+
 local constraints = {
 	Weld       = true,
 	Axis       = true,
@@ -54,7 +56,9 @@ local function CopyClassArgTable(tab)
 					newtable[k] = v
 				end
 			else
-				print("[AdvDupe2] ClassArg table with key \"" .. tostring(k) .. "\" has unsupported value of type \"".. type(v) .."\"!")
+                if debugConvar:GetBool() then
+                    print("[AdvDupe2] ClassArg table with key \"" .. tostring(k) .. "\" has unsupported value of type \"".. type(v) .."\"!")
+                end
 			end
 		end
 		return newtable
@@ -143,9 +147,8 @@ local function CopyEntTable(Ent, Offset)
 					else
 						Tab[Key] = EntTable[Key]
 					end
-				elseif varType ~= TYPE_NIL then
-					print("[AdvDupe2] Entity ClassArg \"" .. Key .. "\" of type \"" .. Ent:GetClass() ..
-									"\" has unsupported value of type \"" .. type(EntTable[Key]) .. "\"!\n")
+				elseif varType ~= TYPE_NIL and debugConvar:GetBool() then
+					print("[AdvDupe2] Entity ClassArg \"" .. Key .. "\" of type \"" .. Ent:GetClass() .. "\" has unsupported value of type \"" .. type(EntTable[Key]) .. "\"!\n")
 				end
 			end
 		end

--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -1476,7 +1476,7 @@ end
 local ticktotal = 0
 local function ErrorCatchSpawning()
 
-	ticktotal = ticktotal + AdvDupe2.SpawnRate
+	ticktotal = ticktotal + math.max(GetConVarNumber("AdvDupe2_SpawnRate"), 0.01)
 	while ticktotal >= 1 do
 		ticktotal = ticktotal - 1
 		local status, err = pcall(AdvDupe2_Spawn)

--- a/lua/autorun/server/advdupe2_sv_init.lua
+++ b/lua/autorun/server/advdupe2_sv_init.lua
@@ -4,7 +4,6 @@ AdvDupe2 = {
 }
 
 AdvDupe2.DataFolder = "advdupe2" --name of the folder in data where dupes will be saved
-AdvDupe2.SpawnRate = 1
 
 function AdvDupe2.Notify(ply,msg,typ, showsvr, dur)
 	net.Start("AdvDupe2Notify")
@@ -58,16 +57,6 @@ CreateConVar("AdvDupe2_UpdateFilesDelay", "10", {FCVAR_ARCHIVE})
 CreateConVar("AdvDupe2_LoadMap", "0", {FCVAR_ARCHIVE})
 CreateConVar("AdvDupe2_MapFileName", "", {FCVAR_ARCHIVE})
 
-cvars.AddChangeCallback("AdvDupe2_SpawnRate",
-function(cvar, preval, newval)
-	newval = tonumber(newval)
-	if(newval~=nil and newval>0)then
-		AdvDupe2.SpawnRate = newval
-	else
-		print("[AdvDupe2Notify]\tINVALID SPAWN RATE")
-	end
-end)
-	
 local function PasteMap()
 	if(GetConVarString("AdvDupe2_LoadMap")=="0")then return end
 	local filename = GetConVarString("AdvDupe2_MapFileName")
@@ -127,15 +116,6 @@ local function PasteMap()
 end
 hook.Add("InitPostEntity", "AdvDupe2_PasteMap", PasteMap)
 hook.Add("PostCleanupMap", "AdvDupe2_PasteMap", PasteMap)
-
-hook.Add("Initialize", "AdvDupe2_CheckServerSettings",function()
-	AdvDupe2.SpawnRate = tonumber(GetConVarString("AdvDupe2_SpawnRate"))
-	if not AdvDupe2.SpawnRate or AdvDupe2.SpawnRate <= 0 then
-		AdvDupe2.SpawnRate = 1
-		print("[AdvDupe2Notify]\tINVALID SPAWN RATE DEFAULTING VALUE")
-	end
-end)
-
 hook.Add("PlayerInitialSpawn","AdvDupe2_AddPlayerTable",function(ply)
 	ply.AdvDupe2 = {}
 end)

--- a/lua/autorun/server/advdupe2_sv_init.lua
+++ b/lua/autorun/server/advdupe2_sv_init.lua
@@ -4,14 +4,19 @@ AdvDupe2 = {
 }
 
 AdvDupe2.DataFolder = "advdupe2" --name of the folder in data where dupes will be saved
+AdvDupe2.SpawnRate = 1
 
-CreateConVar("AdvDupe2_DebugInfo", "0", {FCVAR_ARCHIVE}, "Should extra info be printed to console?", 0, 1)
+function AdvDupe2.Notify(ply,msg,typ, showsvr, dur)
+	net.Start("AdvDupe2Notify")
+		net.WriteString(msg)
+		net.WriteUInt(typ or 0, 8)
+		net.WriteFloat(dur or 5)
+	net.Send(ply)
 
-include "advdupe2/sv_clipboard.lua"
-include "advdupe2/sh_codec.lua"
-include "advdupe2/sv_misc.lua"
-include "advdupe2/sv_file.lua"
-include "advdupe2/sv_ghost.lua"
+	if(showsvr==true)then
+		print("[AdvDupe2Notify]\t"..ply:Nick()..": "..msg)
+	end
+end
 
 AddCSLuaFile "autorun/client/advdupe2_cl_init.lua"
 AddCSLuaFile "advdupe2/file_browser.lua"
@@ -31,20 +36,11 @@ util.AddNetworkString("AdvDupe2_RemoveSelectBox")
 util.AddNetworkString("AdvDupe2_UpdateProgressBar")
 util.AddNetworkString("AdvDupe2_RemoveProgressBar")
 util.AddNetworkString("AdvDupe2_ResetOffsets")
+util.AddNetworkString("AdvDupe2_SetDupeInfo")
+util.AddNetworkString("AdvDupe2_ReceiveFile")
+util.AddNetworkString("AdvDupe2_CanAutoSave")
 
-function AdvDupe2.Notify(ply,msg,typ, showsvr, dur)
-	net.Start("AdvDupe2Notify")
-		net.WriteString(msg)
-		net.WriteUInt(typ or 0, 8)
-		net.WriteFloat(dur or 5)
-	net.Send(ply)
-
-	if(showsvr==true)then
-		print("[AdvDupe2Notify]\t"..ply:Nick()..": "..msg)
-	end
-end
-
-AdvDupe2.SpawnRate = AdvDupe2.SpawnRate or 1
+CreateConVar("AdvDupe2_DebugInfo", "0", {FCVAR_ARCHIVE}, "Should extra info be printed to console?", 0, 1)
 CreateConVar("AdvDupe2_SpawnRate", "1", {FCVAR_ARCHIVE})
 CreateConVar("AdvDupe2_MaxFileSize", "200", {FCVAR_ARCHIVE})
 CreateConVar("AdvDupe2_MaxEntities", "0", {FCVAR_ARCHIVE})
@@ -129,11 +125,6 @@ local function PasteMap()
 	
 	print("[AdvDupe2Notify]\tMap save pasted.")
 end
-
-util.AddNetworkString("AdvDupe2_SetDupeInfo")
-util.AddNetworkString("AdvDupe2_ReceiveFile")
-util.AddNetworkString("AdvDupe2_CanAutoSave")
-
 hook.Add("InitPostEntity", "AdvDupe2_PasteMap", PasteMap)
 hook.Add("PostCleanupMap", "AdvDupe2_PasteMap", PasteMap)
 
@@ -148,4 +139,10 @@ end)
 hook.Add("PlayerInitialSpawn","AdvDupe2_AddPlayerTable",function(ply)
 	ply.AdvDupe2 = {}
 end)
+
+include "advdupe2/sv_clipboard.lua"
+include "advdupe2/sh_codec.lua"
+include "advdupe2/sv_misc.lua"
+include "advdupe2/sv_file.lua"
+include "advdupe2/sv_ghost.lua"
 

--- a/lua/autorun/server/advdupe2_sv_init.lua
+++ b/lua/autorun/server/advdupe2_sv_init.lua
@@ -5,6 +5,8 @@ AdvDupe2 = {
 
 AdvDupe2.DataFolder = "advdupe2" --name of the folder in data where dupes will be saved
 
+CreateConVar("AdvDupe2_DebugInfo", "0", {FCVAR_ARCHIVE}, "Should extra info be printed to console?", 0, 1)
+
 include "advdupe2/sv_clipboard.lua"
 include "advdupe2/sh_codec.lua"
 include "advdupe2/sv_misc.lua"


### PR DESCRIPTION
Hides this kind of spam behind a convar. A single dupe can currently easily cause ~200 prints while the information isn't that useful.
![image](https://github.com/wiremod/advdupe2/assets/69946827/9b95879d-fde4-45bf-ad88-f7b7e0465d57)
