### PR TITLE
Fix copying special "Data" attribute

### DIFF
--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -136,6 +136,9 @@ local function CopyEntTable(Ent, Offset)
 
 	if EntityClass then
 		for iNumber, Key in pairs(EntityClass.Args) do
+			if gtSetupTable.SPECIAL[Key] then
+				Tab = CopyClassArgTable(EntTable)
+			end
 			-- Ignore keys from old system
 			if (not gtSetupTable.POS[Key] and
 					not gtSetupTable.ANG[Key] and


### PR DESCRIPTION
As noted on [`duplicator.RegisterEntityClass`](https://wiki.facepunch.com/gmod/duplicator.RegisterEntityClass) there is a special case "Data" that can be provided to tell it to essentially copy the entire entities data structure and any properties set on it.

This appears to be broken in advdupe2 (working in built-in duplicator) in that while [it does handle it on the pasting side](https://github.com/wiremod/advdupe2/blob/master/lua/advdupe2/sv_clipboard.lua#L976-L979), it does not handle it on the copying side properly.

This PR fixes that, and replaces the entire entity copy table with a copy of the entity table, just like it does in reverse on the pasting end, and just like how the built in duplicator does it as well.

I'm not going to say this is definitely the perfect or correct fix and there may well be good reasons as to why it's done the way it is, I'm no expert on this codebase but there is a clear regression with comparison to the built in duplicator here.

I've tested this against an experimental version of my TARDIS addon with duplicator support which is how I found this issue, we're using the special "Data" case because we're going for "best effort" duplication and it seems to work pretty well. If you'd like to test it yourself you can do so on the [`saves_dupes_fix`](https://github.com/MattJeanes/TARDIS/tree/saves_dupes_fix) branch of the addon (if it doesn't exist when you click it it's because it's been merged into `dev` since).

Thanks!