### PR TITLE
Track revision in Queue to avoid bad backwards compat

### DIFF
--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -1550,7 +1550,7 @@ local function RemoveSpawnedEntities(tbl, i)
 	end
 end
 
-function AdvDupe2.InitPastingQueue(Player, PositionOffset, AngleOffset, OrigPos, Constrs, Parenting, DisableParents, DisableProtection, revision)
+function AdvDupe2.InitPastingQueue(Player, PositionOffset, AngleOffset, OrigPos, Constrs, Parenting, DisableParents, DisableProtection)
 	local i = #AdvDupe2.JobManager.Queue + 1
 
 	local Queue = {
@@ -1568,7 +1568,7 @@ function AdvDupe2.InitPastingQueue(Player, PositionOffset, AngleOffset, OrigPos,
 		CreatedConstraints = {},
 		PositionOffset = PositionOffset or Vector(0, 0, 0),
 		AngleOffset = AngleOffset or Angle(0, 0, 0),
-		Revision = revision or Player.AdvDupe2.Revision,
+		Revision = Player.AdvDupe2.Revision,
 	}
 	AdvDupe2.JobManager.Queue[i] = Queue
 

--- a/lua/advdupe2/sv_file.lua
+++ b/lua/advdupe2/sv_file.lua
@@ -66,6 +66,7 @@ function AdvDupe2.LoadDupe(ply,success,dupe,info,moreinfo)
 	ply.AdvDupe2.Entities = {}
 	ply.AdvDupe2.Constraints = {}
 	ply.AdvDupe2.HeadEnt={}
+	ply.AdvDupe2.Revision = info.revision
 
 	if(info.ad1)then
 


### PR DESCRIPTION
Fixes #441 (see https://github.com/wiremod/advdupe2/issues/441#issuecomment-1784280335)

This avoids using `LocalPos` field of `v` if not in AdvDupe1 mode. I don't know if this needs to be done for any other fields, or if the struct should be rewritten, because I cannot comprehend it.

Extra code changes include fixing a local from a global, removing an unused local, cleaning up initialization of `Queue` object.