### PR TITLE
Invalid model reporting fix

### DIFF
--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -797,7 +797,7 @@ local function reportclass(ply, class)
 end
 
 local function reportmodel(ply, model)
-	net.Start("AdvDupe2_ReportClass")
+	net.Start("AdvDupe2_ReportModel")
 	net.WriteString(model)
 	net.Send(ply)
 end


### PR DESCRIPTION
Fixes error when 'invalid model' errors are displayed as 'invalid class' errors.