### PR TITLE
Add `AdvDupe2_PreCreateEntity` hook

### DIFF
--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -906,6 +906,7 @@ local function IsAllowed(Player, Class, EntityClass)
 end
 
 local function CreateEntityFromTable(EntTable, Player)
+	hook.Run("AdvDupe2_PreCreateEntity", EntTable, Player)
 
 	local EntityClass = duplicator.FindEntityClass(EntTable.Class)
 	if not IsAllowed(Player, EntTable.Class, EntityClass) then


### PR DESCRIPTION
Adds `AdvDupe2_PreCreateEntity` hook called before all actions in `CreateEntityFromTable`.
It is supposed to be used to modify EntTable before creating this entity.
I use it to fix renamed models in existing dupes.