### PR TITLE
Fixed a crash exploit

### DIFF
--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -844,6 +844,8 @@ end
 ]]
 local function MakeProp(Player, Pos, Ang, Model, PhysicsObject, Data)
 
+    if Data.ModelScale and Data.ModelScale == 0 then return end // Crashes dedicated servers when model scale is set to 0 in dupes. Skip the prop.
+
 	if (not util.IsValidModel(Model) and not file.Exists(Data.Model, "GAME")) then
 		if (Player) then
 			reportmodel(Player, Data.Model)

--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -844,7 +844,7 @@ end
 ]]
 local function MakeProp(Player, Pos, Ang, Model, PhysicsObject, Data)
 
-    if Data.ModelScale and Data.ModelScale == 0 then return end // Crashes dedicated servers when model scale is set to 0 in dupes. Skip the prop.
+    if Data.ModelScale then Data.ModelScale = math.Clamp(Data.ModelScale, 1e-5, 1e5) end
 
 	if (not util.IsValidModel(Model) and not file.Exists(Data.Model, "GAME")) then
 		if (Player) then


### PR DESCRIPTION
Spawning props with model scale set to 0 crashes dedicated servers. By adding this line of code, the MakeProp function will skip anything with ModelScale set to 0. Developers can modify this part of the code to detect people attempting to crash their server.