### PR TITLE
Fix AreaCopy when used with the CopyOutside param

### DIFF
--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -446,10 +446,9 @@ AdvDupe2.duplicator.Copy = Copy
 --[[
 	Name: AreaCopy
 	Desc: Copy based on a box
-	Params: <entity> Entity
 	Returns: <table> Entities, <table> Constraints
 ]]
-function AdvDupe2.duplicator.AreaCopy(Entities, Offset, CopyOutside, ply)
+function AdvDupe2.duplicator.AreaCopy(ply, Entities, Offset, CopyOutside)
 	local Constraints, EntTable, ConstraintTable = {}, {}, {}
 	local index, add, AddEnts, AddConstrs, ConstTable, EntTab
 

--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -449,7 +449,7 @@ AdvDupe2.duplicator.Copy = Copy
 	Params: <entity> Entity
 	Returns: <table> Entities, <table> Constraints
 ]]
-function AdvDupe2.duplicator.AreaCopy(Entities, Offset, CopyOutside)
+function AdvDupe2.duplicator.AreaCopy(Entities, Offset, CopyOutside, ply)
 	local Constraints, EntTable, ConstraintTable = {}, {}, {}
 	local index, add, AddEnts, AddConstrs, ConstTable, EntTab
 
@@ -492,7 +492,7 @@ function AdvDupe2.duplicator.AreaCopy(Entities, Offset, CopyOutside)
 		else -- Copy entities and constraints outside of the box that are constrained to entities inside the box
 			ConstraintTable[_] = ConstTable
 			for k, v in pairs(EntTab) do
-				Copy(v, EntTable, ConstraintTable, Offset)
+				Copy(ply, v, EntTable, ConstraintTable, Offset)
 			end
 		end
 	end

--- a/lua/weapons/gmod_tool/stools/advdupe2.lua
+++ b/lua/weapons/gmod_tool/stools/advdupe2.lua
@@ -289,7 +289,7 @@ if(SERVER) then
 			HeadEnt.Index = Ent:EntIndex()
 			HeadEnt.Pos = Ent:GetPos()
 
-			Entities, Constraints = AdvDupe2.duplicator.AreaCopy(Ents, HeadEnt.Pos, tobool(ply:GetInfo("advdupe2_copy_outside")))
+			Entities, Constraints = AdvDupe2.duplicator.AreaCopy(Ents, HeadEnt.Pos, tobool(ply:GetInfo("advdupe2_copy_outside")), ply)
 
 			self:SetStage(0)
 			AdvDupe2.RemoveSelectBox(ply)
@@ -348,7 +348,7 @@ if(SERVER) then
 				HeadEnt.Index = Ent:EntIndex()
 				HeadEnt.Pos = Ent:GetPos()
 
-				Entities, Constraints = AdvDupe2.duplicator.AreaCopy(Entities, HeadEnt.Pos, tobool(ply:GetInfo("advdupe2_copy_outside")))
+				Entities, Constraints = AdvDupe2.duplicator.AreaCopy(Entities, HeadEnt.Pos, tobool(ply:GetInfo("advdupe2_copy_outside")), ply)
 			end
 		end
 
@@ -782,7 +782,7 @@ if(SERVER) then
 				})
 
 				Tab.HeadEnt.Z = WorldTrace.Hit and math.abs(Tab.HeadEnt.Pos.Z - WorldTrace.HitPos.Z) or 0
-				Tab.Entities, Tab.Constraints = AdvDupe2.duplicator.AreaCopy(Entities, Tab.HeadEnt.Pos, dupe.AutoSaveOutSide)
+				Tab.Entities, Tab.Constraints = AdvDupe2.duplicator.AreaCopy(Entities, Tab.HeadEnt.Pos, dupe.AutoSaveOutSide, ply)
 			end
 			Tab.Constraints = GetSortedConstraints(ply, Tab.Constraints)
 			Tab.Description = dupe.AutoSaveDesc
@@ -830,7 +830,7 @@ if(SERVER) then
 		})
 
 		Tab.HeadEnt.Z = WorldTrace.Hit and math.abs(Tab.HeadEnt.Pos.Z - WorldTrace.HitPos.Z) or 0
-		Tab.Entities, Tab.Constraints = AdvDupe2.duplicator.AreaCopy(Entities, Tab.HeadEnt.Pos, true)
+		Tab.Entities, Tab.Constraints = AdvDupe2.duplicator.AreaCopy(Entities, Tab.HeadEnt.Pos, true, ply)
 		Tab.Constraints = GetSortedConstraints(ply, Tab.Constraints)
 
 		Tab.Map = true

--- a/lua/weapons/gmod_tool/stools/advdupe2.lua
+++ b/lua/weapons/gmod_tool/stools/advdupe2.lua
@@ -289,7 +289,7 @@ if(SERVER) then
 			HeadEnt.Index = Ent:EntIndex()
 			HeadEnt.Pos = Ent:GetPos()
 
-			Entities, Constraints = AdvDupe2.duplicator.AreaCopy(Ents, HeadEnt.Pos, tobool(ply:GetInfo("advdupe2_copy_outside")), ply)
+			Entities, Constraints = AdvDupe2.duplicator.AreaCopy(ply, Ents, HeadEnt.Pos, tobool(ply:GetInfo("advdupe2_copy_outside")))
 
 			self:SetStage(0)
 			AdvDupe2.RemoveSelectBox(ply)
@@ -348,7 +348,7 @@ if(SERVER) then
 				HeadEnt.Index = Ent:EntIndex()
 				HeadEnt.Pos = Ent:GetPos()
 
-				Entities, Constraints = AdvDupe2.duplicator.AreaCopy(Entities, HeadEnt.Pos, tobool(ply:GetInfo("advdupe2_copy_outside")), ply)
+				Entities, Constraints = AdvDupe2.duplicator.AreaCopy(ply, Entities, HeadEnt.Pos, tobool(ply:GetInfo("advdupe2_copy_outside")))
 			end
 		end
 
@@ -782,7 +782,7 @@ if(SERVER) then
 				})
 
 				Tab.HeadEnt.Z = WorldTrace.Hit and math.abs(Tab.HeadEnt.Pos.Z - WorldTrace.HitPos.Z) or 0
-				Tab.Entities, Tab.Constraints = AdvDupe2.duplicator.AreaCopy(Entities, Tab.HeadEnt.Pos, dupe.AutoSaveOutSide, ply)
+				Tab.Entities, Tab.Constraints = AdvDupe2.duplicator.AreaCopy(ply, Entities, Tab.HeadEnt.Pos, dupe.AutoSaveOutSide)
 			end
 			Tab.Constraints = GetSortedConstraints(ply, Tab.Constraints)
 			Tab.Description = dupe.AutoSaveDesc
@@ -830,7 +830,7 @@ if(SERVER) then
 		})
 
 		Tab.HeadEnt.Z = WorldTrace.Hit and math.abs(Tab.HeadEnt.Pos.Z - WorldTrace.HitPos.Z) or 0
-		Tab.Entities, Tab.Constraints = AdvDupe2.duplicator.AreaCopy(Entities, Tab.HeadEnt.Pos, true, ply)
+		Tab.Entities, Tab.Constraints = AdvDupe2.duplicator.AreaCopy(ply, Entities, Tab.HeadEnt.Pos, true)
 		Tab.Constraints = GetSortedConstraints(ply, Tab.Constraints)
 
 		Tab.Map = true


### PR DESCRIPTION
### Problem Summary
The Copy function takes a `ply` so it can determine which entities to copy:
https://github.com/wiremod/advdupe2/blob/master/lua/advdupe2/sv_clipboard.lua#L376

But when the `CopyOutside` param is enabled in `AreaCopy`, it doesn't pass a `ply` in:
https://github.com/wiremod/advdupe2/blob/master/lua/advdupe2/sv_clipboard.lua#L495

So when using the `CopyOutside` param with `AreaCopy`, an error is produced:
```
[advdupe2] addons/advdupe2/lua/advdupe2/sv_clipboard.lua:379: attempt to call method 'EntIndex' (a nil value)
  1. RecursiveCopy - addons/advdupe2/lua/advdupe2/sv_clipboard.lua:379
   2. Copy - addons/advdupe2/lua/advdupe2/sv_clipboard.lua:440
    3. AreaCopy - addons/advdupe2/lua/advdupe2/sv_clipboard.lua:495
     4. RightClick - addons/advdupe2/lua/weapons/gmod_tool/stools/advdupe2.lua:292
      5. unknown - gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua:257
```

### The Fix
I've updated the `AreaCopy` function to take `ply` as the last parameter, which is then passed through to the `Copy` function correctly.

I also updated all of the instances of `AreaCopy` to provide a `ply`.

I'm not 100% sure this is the best way, but it does address the issue.


### Reproduce
- Adv2 on `master`
- Spawn 2 props, weld them together
- Area copy, including only one of the props
- Error is thrown in server console, only one prop is included in the ghost
