### PR TITLE
Account for no menu binding

### DIFF
--- a/lua/advdupe2/file_browser.lua
+++ b/lua/advdupe2/file_browser.lua
@@ -1226,8 +1226,7 @@ function PANEL:Init()
 	self.FileName.OnTextChanged = function()
 
 		if (self.FileName.FirstChar) then
-			if (string.lower(self.FileName:GetValue()[1] or "") ==
-				string.lower(input.LookupBinding("menu"))) then
+			if (string.lower(self.FileName:GetValue()[1] or "") == string.lower(input.LookupBinding("menu") or "q")) then
 				self.FileName:SetText(self.FileName.PrevText)
 				self.FileName:SelectAll()
 				self.FileName.FirstChar = false


### PR DESCRIPTION
Saw a player constantly getting this error
```
bad argument #1 to 'lower' (string expected, got no value)
1.  lower - [C]:-1 
 2.  unknown - addons/advdupe2/lua/advdupe2/file_browser.lua:1230
```

The default for `input.LookupBinding("menu")` is q
`input.LookupBinding` returns `nil` when no binding is found <https://wiki.facepunch.com/gmod/input.LookupBinding>
It seems like it should either default to `"q"` or `""`, i've chosen for q as it makes logical sense but i can change it if preferred.