### PR TITLE
Add AdvDupe2.SanitizeFilename

### DIFF
--- a/lua/advdupe2/cl_file.lua
+++ b/lua/advdupe2/cl_file.lua
@@ -7,7 +7,7 @@ function AdvDupe2.SanitizeFilename(filename)
 
 	return filename
 end
---path = string.Replace(path, " ", "_")
+
 local function AdvDupe2_ReceiveFile(len, ply)
 	local AutoSave = net.ReadUInt(8) == 1
 

--- a/lua/advdupe2/cl_file.lua
+++ b/lua/advdupe2/cl_file.lua
@@ -1,9 +1,9 @@
 local invalidCharacters = { "\"", ":"}
 function AdvDupe2.SanitizeFilename(filename)
-	-- for i=1, #invalidCharacters do
-	-- 	filename = string.gsub(filename, invalidCharacters[i], "_")
-	-- end
-	-- filename = string.gsub(filename, "%s+", " ")
+	for i=1, #invalidCharacters do
+		filename = string.gsub(filename, invalidCharacters[i], "_")
+	end
+	filename = string.gsub(filename, "%s+", " ")
 
 	return filename
 end

--- a/lua/advdupe2/cl_file.lua
+++ b/lua/advdupe2/cl_file.lua
@@ -1,3 +1,13 @@
+local invalidCharacters = { "\"", ":"}
+function AdvDupe2.SanitizeFilename(filename)
+	-- for i=1, #invalidCharacters do
+	-- 	filename = string.gsub(filename, invalidCharacters[i], "_")
+	-- end
+	-- filename = string.gsub(filename, "%s+", " ")
+
+	return filename
+end
+--path = string.Replace(path, " ", "_")
 local function AdvDupe2_ReceiveFile(len, ply)
 	local AutoSave = net.ReadUInt(8) == 1
 
@@ -18,6 +28,7 @@ local function AdvDupe2_ReceiveFile(len, ply)
 			path = AdvDupe2.GetFilename(AdvDupe2.SavePath)
 		end
 
+		path = AdvDupe2.SanitizeFilename(path)
 		local dupefile = file.Open(path, "wb", "DATA")
 		if(!dupefile)then
 			AdvDupe2.Notify("File was not saved!",NOTIFY_ERROR,5)

--- a/lua/advdupe2/file_browser.lua
+++ b/lua/advdupe2/file_browser.lua
@@ -306,6 +306,8 @@ local function RenameFileCl(node, name)
 		AdvDupe2.Notify("Rename limit exceeded, could not rename.", NOTIFY_ERROR)
 		return
 	end
+
+	FilePath = AdvDupe2.SanitizeFilename(FilePath)
 	file.Write(FilePath, File)
 	if (file.Exists(FilePath, "DATA")) then
 		file.Delete(tempFilePath .. ".txt")

--- a/lua/advdupe2/sh_codec.lua
+++ b/lua/advdupe2/sh_codec.lua
@@ -524,6 +524,8 @@ if CLIENT then
 		local readFileName = "advdupe2/"..arg[1]
 		local writeFileName = "advdupe2/"..string.StripExtension(arg[1])..".json"
 
+		writeFileName = AdvDupe2.SanitizeFilename(writeFileName)
+
 		local readFile = file.Open(readFileName, "rb", "DATA")
 		if not readFile then print("File could not be read or found! ("..readFileName..")") return end
 		local readData = readFile:Read(readFile:Size())


### PR DESCRIPTION
Currently if you try to save a file with two spaces in it it'll fail to save, i've seen quite a few people having issues with this.
Also blacklists invalid characters seen here <https://wiki.facepunch.com/gmod/file.Write>
![image](https://github.com/user-attachments/assets/0ce531b5-8296-41a3-b6c4-1b7eba923817)
