### PR TITLE
Use TOOL.Information HUD formatting

### DIFF
--- a/lua/weapons/gmod_tool/stools/advdupe2.lua
+++ b/lua/weapons/gmod_tool/stools/advdupe2.lua
@@ -1001,14 +1001,29 @@ if(CLIENT) then
 		return AdvDupe2.Rotation
 	end
 
-	language.Add( "Tool.advdupe2.name",	"Advanced Duplicator 2" )
-	language.Add( "Tool.advdupe2.desc",	"Duplicate things." )
-	language.Add( "Tool.advdupe2.0",	"Primary: Paste, Secondary: Copy, Secondary+World: Select/Deselect All, Secondary+Shift: Area copy." )
-	language.Add( "Tool.advdupe2.1",	"Primary: Paste, Secondary: Copy an area, Reload: Autosave an area, Secondary+Shift: Cancel." )
-	language.Add( "Undone_AdvDupe2",	"Undone AdvDupe2 paste" )
-	language.Add( "Cleanup_AdvDupe2",	"AdvDupe2 Duplications" )
-	language.Add( "Cleaned_AdvDupe2",	"Cleaned up all AdvDupe2 Duplications" )
-	language.Add( "SBoxLimit_AdvDupe2",	"You've reached the AdvDupe2 Duplicator limit!" )
+	TOOL.Information = {
+		{ name = "left" },
+		{ name = "right", stage = 0 },
+		{ name = "right_world", stage = 0, icon2 = "gui/info" },
+		{ name = "right_shift", stage = 0, icon2 = "gui/info" },
+		{ name = "right_alt", stage = 1 },
+		{ name = "reload_alt", stage = 1 },
+		{ name = "right_shift_alt", stage = 1, icon2 = "gui/info" },
+	}
+
+	language.Add( "Tool.advdupe2.name",				"Advanced Duplicator 2" )
+	language.Add( "Tool.advdupe2.desc",				"Duplicate things." )
+	language.Add( "Tool.advdupe2.left",				"Paste" )
+	language.Add( "Tool.advdupe2.right",			"Copy" )
+	language.Add( "Tool.advdupe2.right_world",		"Hit the world to select/deselect all" )
+	language.Add( "Tool.advdupe2.right_shift",		"Press Shift to area copy" )
+	language.Add( "Tool.advdupe2.right_alt",		"Copy an area" )
+	language.Add( "Tool.advdupe2.reload_alt",		"Autosave an area" )
+	language.Add( "Tool.advdupe2.right_shift_alt",	"Press Shift to cancel" )
+	language.Add( "Undone_AdvDupe2",				"Undone AdvDupe2 paste" )
+	language.Add( "Cleanup_AdvDupe2",				"AdvDupe2 Duplications" )
+	language.Add( "Cleaned_AdvDupe2",				"Cleaned up all AdvDupe2 Duplications" )
+	language.Add( "SBoxLimit_AdvDupe2",				"You've reached the AdvDupe2 Duplicator limit!" )
 
 	CreateClientConVar("advdupe2_offset_world", 0, false, true)
 	CreateClientConVar("advdupe2_offset_z", 0, false, true)


### PR DESCRIPTION
Makes the tool info HUD use the same format as the game's default tools.

![image](https://github.com/user-attachments/assets/5d11c552-e2a7-4413-a06c-0d1ce24d7617)
