### PR TITLE
Add adjustable ghost rate

### DIFF
--- a/lua/advdupe2/cl_ghost.lua
+++ b/lua/advdupe2/cl_ghost.lua
@@ -196,7 +196,7 @@ local function SpawnGhosts()
 
 	for i = AdvDupe2.CurrentGhost, finalGhostInFrame do
 		local g = AdvDupe2.GhostToSpawn[i]
-		if g then AdvDupe2.GhostEntities[i] = MakeGhostsFromTable( g ) end
+		if g and i ~= AdvDupe2.HeadEnt then AdvDupe2.GhostEntities[i] = MakeGhostsFromTable( g ) end
 	end
 	AdvDupe2.CurrentGhost = finalGhostInFrame + 1
 

--- a/lua/advdupe2/cl_ghost.lua
+++ b/lua/advdupe2/cl_ghost.lua
@@ -192,18 +192,12 @@ local function SpawnGhosts()
 	local ghostPercentLimit = GetConVar( "advdupe2_limit_ghost" ):GetFloat()
 
 	local currentGhost = AdvDupe2.CurrentGhost
-	local totalGhosts = AdvDupe2.TotalGhosts
-	local ghostToSpawn = AdvDupe2.GhostToSpawn
-	local ghostEntities = AdvDupe2.GhostEntities
-	local ProgressBar = AdvDupe2.ProgressBar
-	local BusyBar = AdvDupe2.BusyBar
-
 	if currentGhost == AdvDupe2.HeadEnt then currentGhost = currentGhost + 1 end
 
-	local maxByPercent = math.floor((ghostPercentLimit / 100) * totalGhosts )
-	if maxByPercent > totalGhosts then maxByPercent = totalGhosts end
+	local maxByPercent = math.floor((ghostPercentLimit / 100) * AdvDupe2.TotalGhosts )
+	if maxByPercent > AdvDupe2.TotalGhosts then maxByPercent = AdvDupe2.TotalGhosts end
 
-	local ghostsRemaining = totalGhosts - currentGhost + 1
+	local ghostsRemaining = AdvDupe2.TotalGhosts - currentGhost + 1
 	local allowedByPercent = maxByPercent - currentGhost + 1
 	if allowedByPercent < 0 then allowedByPercent = 0 end
 
@@ -211,22 +205,24 @@ local function SpawnGhosts()
 	local target = currentGhost + spawnThisTick - 1
 
 	for _ = 1, spawnThisTick do
-		local g = ghostToSpawn[currentGhost]
+		local g = AdvDupe2.GhostToSpawn[currentGhost]
 		if not g then break end
 
-		ghostEntities[currentGhost] = MakeGhostsFromTable( g )
+		AdvDupe2.GhostEntities[currentGhost] = MakeGhostsFromTable( g )
 		currentGhost = currentGhost + 1
 	end
 
 	AdvDupe2.CurrentGhost = currentGhost
 	AdvDupe2.UpdateGhosts( true )
-	if not BusyBar then ProgressBar.Percent = (currentGhost / totalGhosts) * 100 end
+	if not AdvDupe2.BusyBar then
+		AdvDupe2.ProgressBar.Percent = (currentGhost / AdvDupe2.TotalGhosts) * 100
+	end
 
 	-- If the loop broke early
 	if (currentGhost - 1) ~= target then StopGhosting() return end
 
 	-- If all ghosts are spawned
-	local maxGhosts = math.min( totalGhosts, maxByPercent )
+	local maxGhosts = math.min( AdvDupe2.TotalGhosts, maxByPercent )
 	if currentGhost > maxGhosts then StopGhosting() return end
 end
 

--- a/lua/advdupe2/cl_ghost.lua
+++ b/lua/advdupe2/cl_ghost.lua
@@ -188,15 +188,15 @@ local function StopGhosting()
 end
 
 local function SpawnGhosts()
-	local ghostsPerTick     = GetConVar( "advdupe2_ghost_rate" ):GetInt()
+	local ghostsPerTick = GetConVar( "advdupe2_ghost_rate" ):GetInt()
 	local ghostPercentLimit = GetConVar( "advdupe2_limit_ghost" ):GetFloat()
 
-	local currentGhost      = AdvDupe2.CurrentGhost
-	local totalGhosts       = AdvDupe2.TotalGhosts
-	local ghostToSpawn      = AdvDupe2.GhostToSpawn
-	local ghostEntities     = AdvDupe2.GhostEntities
-	local ProgressBar       = AdvDupe2.ProgressBar
-	local BusyBar           = AdvDupe2.BusyBar
+	local currentGhost = AdvDupe2.CurrentGhost
+	local totalGhosts = AdvDupe2.TotalGhosts
+	local ghostToSpawn = AdvDupe2.GhostToSpawn
+	local ghostEntities = AdvDupe2.GhostEntities
+	local ProgressBar = AdvDupe2.ProgressBar
+	local BusyBar = AdvDupe2.BusyBar
 
 	if currentGhost == AdvDupe2.HeadEnt then currentGhost = currentGhost + 1 end
 

--- a/lua/weapons/gmod_tool/stools/advdupe2.lua
+++ b/lua/weapons/gmod_tool/stools/advdupe2.lua
@@ -1039,7 +1039,7 @@ if(CLIENT) then
 	CreateClientConVar("advdupe2_copy_outside", 0, false, true)
 	CreateClientConVar("advdupe2_copy_only_mine", 1, false, true)
 	CreateClientConVar("advdupe2_limit_ghost", 100, false, true)
-	CreateClientConVar("advdupe2_ghost_rate", 5, false, true, nil, 1, 50)
+	CreateClientConVar("advdupe2_ghost_rate", 5, true, true, nil, 1, 50)
 	CreateClientConVar("advdupe2_area_copy_size", 300, false, true)
 	CreateClientConVar("advdupe2_auto_save_contraption", 0, false, true)
 	CreateClientConVar("advdupe2_auto_save_overwrite", 1, false, true)

--- a/lua/weapons/gmod_tool/stools/advdupe2.lua
+++ b/lua/weapons/gmod_tool/stools/advdupe2.lua
@@ -1167,7 +1167,7 @@ if(CLIENT) then
 		NumSlider:SetText( "Ghost speed:" )
 		NumSlider.Label:SetDark(true)
 		NumSlider:SetMin( 1 )
-		NumSlider:SetMax( 100 )
+		NumSlider:SetMax( 50 )
 		NumSlider:SetDecimals( 0 )
 		NumSlider:SetConVar( "advdupe2_ghost_rate" )
 		NumSlider:SetToolTip("Change how quickly the ghosts are generated")

--- a/lua/weapons/gmod_tool/stools/advdupe2.lua
+++ b/lua/weapons/gmod_tool/stools/advdupe2.lua
@@ -1039,6 +1039,7 @@ if(CLIENT) then
 	CreateClientConVar("advdupe2_copy_outside", 0, false, true)
 	CreateClientConVar("advdupe2_copy_only_mine", 1, false, true)
 	CreateClientConVar("advdupe2_limit_ghost", 100, false, true)
+	CreateClientConVar("advdupe2_ghost_rate", 5, false, true, nil, 1, 50)
 	CreateClientConVar("advdupe2_area_copy_size", 300, false, true)
 	CreateClientConVar("advdupe2_auto_save_contraption", 0, false, true)
 	CreateClientConVar("advdupe2_auto_save_overwrite", 1, false, true)
@@ -1143,6 +1144,7 @@ if(CLIENT) then
 		Check:SetToolTip( "Orders constraints so that they build a rigid constraint system." )
 		CPanel:AddItem(Check)
 
+		-- Ghost Percentage
 		local NumSlider = vgui.Create( "DNumSlider" )
 		NumSlider:SetText( "Ghost Percentage:" )
 		NumSlider.Label:SetDark(true)
@@ -1160,6 +1162,18 @@ if(CLIENT) then
 		NumSlider.Wang.Panel.OnLoseFocus = function(txtBox) func3(txtBox) AdvDupe2.StartGhosting() end
 		CPanel:AddItem(NumSlider)
 
+		-- Ghost Rate
+		NumSlider = vgui.Create( "DNumSlider" )
+		NumSlider:SetText( "Ghost speed:" )
+		NumSlider.Label:SetDark(true)
+		NumSlider:SetMin( 1 )
+		NumSlider:SetMax( 100 )
+		NumSlider:SetDecimals( 0 )
+		NumSlider:SetConVar( "advdupe2_ghost_rate" )
+		NumSlider:SetToolTip("Change how quickly the ghosts are generated")
+		CPanel:AddItem(NumSlider)
+
+		-- Area Copy Size
 		NumSlider = vgui.Create( "DNumSlider" )
 		NumSlider:SetText( "Area Copy Size:" )
 		NumSlider.Label:SetDark(true)

--- a/lua/weapons/gmod_tool/stools/advdupe2.lua
+++ b/lua/weapons/gmod_tool/stools/advdupe2.lua
@@ -1038,7 +1038,7 @@ if(CLIENT) then
 	CreateClientConVar("advdupe2_preserve_freeze", 0, false, true)
 	CreateClientConVar("advdupe2_copy_outside", 0, false, true)
 	CreateClientConVar("advdupe2_copy_only_mine", 1, false, true)
-	CreateClientConVar("advdupe2_limit_ghost", 100, false, true)
+	CreateClientConVar("advdupe2_limit_ghost", 100, false, true, nil, 0, 100)
 	CreateClientConVar("advdupe2_ghost_rate", 5, true, true, nil, 1, 50)
 	CreateClientConVar("advdupe2_area_copy_size", 300, false, true)
 	CreateClientConVar("advdupe2_auto_save_contraption", 0, false, true)


### PR DESCRIPTION
### Description
Clientside ghosting can be slow. It's capped at generating one entity per `Tick`.

I feel like this is an outdated limit. Spawning them orders of magnitude more often doesn't seem to have any performance impact.

### Solution
I added a new convar + slider that adjusts how many ghosts are spawned per tick. This option is defaulted to `5` which will be 5x faster for everyone by default (and should be safe enough)

### Demo

https://github.com/user-attachments/assets/3371242a-f5ff-42fc-a515-b2b508482471

