### PR TITLE
Fix double-clicking search result in file_browser.lua

### DIFF
--- a/lua/advdupe2/file_browser.lua
+++ b/lua/advdupe2/file_browser.lua
@@ -173,7 +173,7 @@ function BROWSER:DoNodeLeftClick(node)
 				node:SetExpanded() -- It's a folder, expand/collapse it
 			end
 		else
-			AdvDupe2.UploadFile(GetNodePath(node))
+			AdvDupe2.UploadFile(GetNodePath(node.Ref))
 		end
 	else
 		self:SetSelected(node) -- A node was clicked, select it
@@ -440,7 +440,7 @@ function BROWSER:DoNodeRightClick(node)
 			end)
 		else
 			Menu:AddOption("Open", function()
-				AdvDupe2.UploadFile(GetNodePath(node))
+				AdvDupe2.UploadFile(GetNodePath(node.Ref))
 			end)
 			Menu:AddOption("Preview", function()
 				local ReadPath, ReadArea = GetNodePath(node)


### PR DESCRIPTION
Double-clicking an item in the search results would return an error - "file not found". Pass `node.Ref` to GetNodePath() instead.