### PR TITLE
Add AdvDupe2_CanCreateClass hook

### DIFF
--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -923,6 +923,12 @@ local function CreateEntityFromTable(EntTable, Player)
 		return nil
 	end
 
+	local blocked, blockReason = hook.Run( "AdvDupe2_BlockCreateEntity", Player, Class )
+	if blocked == true then
+		Player:ChatPrint([[Entity Class, "]] .. EntTable.Class .. [[" Blocked! ']] .. blockReason .. [[']] )
+		return nil
+	end
+
 	local sent = false
 	local status, valid
 	local GENERIC = false

--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -923,9 +923,14 @@ local function CreateEntityFromTable(EntTable, Player)
 		return nil
 	end
 
-	local blocked, blockReason = hook.Run( "AdvDupe2_BlockCreateEntity", Player, Class )
+	local blocked, blockReason = hook.Run( "AdvDupe2_BlockCreateEntity", Player, EntTable.Class )
 	if blocked == true then
-		Player:ChatPrint([[Entity Class, "]] .. EntTable.Class .. [[" Blocked! ']] .. blockReason .. [[']] )
+		local msg = [[Entity Class, "]] .. EntTable.Class .. [[" is Blocked! ]]
+		if isstring( blockReason ) then
+			msg = msg .. blockReason
+
+		end
+		Player:ChatPrint( msg )
 		return nil
 	end
 

--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -923,7 +923,7 @@ local function CreateEntityFromTable(EntTable, Player)
 		return nil
 	end
 
-	local canCreate, blockReason = hook.Run( "AdvDupe2_CanSpawn", Player, EntTable.Class )
+	local canCreate, blockReason = hook.Run( "AdvDupe2_CanCreateEntity", Player, EntTable.Class )
 	if canCreate == false then
 		local msg = [[Entity Class, "]] .. EntTable.Class .. [[" is Blocked! ]]
 		if isstring( blockReason ) then -- allow nil blockReason

--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -926,7 +926,7 @@ local function CreateEntityFromTable(EntTable, Player)
 	local blocked, blockReason = hook.Run( "AdvDupe2_BlockCreateEntity", Player, EntTable.Class )
 	if blocked == true then
 		local msg = [[Entity Class, "]] .. EntTable.Class .. [[" is Blocked! ]]
-		if isstring( blockReason ) then
+		if isstring( blockReason ) then -- allow nil blockReason
 			msg = msg .. blockReason
 
 		end

--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -923,7 +923,7 @@ local function CreateEntityFromTable(EntTable, Player)
 		return nil
 	end
 
-	local canCreate, blockReason = hook.Run( "AdvDupe2_CanCreateClass", Player, EntTable.Class )
+	local canCreate, blockReason = hook.Run( "AdvDupe2_CanSpawn", Player, EntTable.Class )
 	if canCreate == false then
 		local msg = [[Entity Class, "]] .. EntTable.Class .. [[" is Blocked! ]]
 		if isstring( blockReason ) then -- allow nil blockReason

--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -923,8 +923,8 @@ local function CreateEntityFromTable(EntTable, Player)
 		return nil
 	end
 
-	local blocked, blockReason = hook.Run( "AdvDupe2_BlockCreateEntity", Player, EntTable.Class )
-	if blocked == true then
+	local canCreate, blockReason = hook.Run( "AdvDupe2_CanCreateClass", Player, EntTable.Class )
+	if canCreate == false then
 		local msg = [[Entity Class, "]] .. EntTable.Class .. [[" is Blocked! ]]
 		if isstring( blockReason ) then -- allow nil blockReason
 			msg = msg .. blockReason


### PR DESCRIPTION
Was facing issues with players sneaking past PlayerSpawnSENT, and when i was looking through the advdupe2 code I realized that there's no "correct" way to stop CreateEntityFromTable from spawning a class

So here's a hook to address that.
AdvDupe2_CanCreateClass, Player, Class
Can return two args
If arg1 is false then the paste is blocked, and arg2 is printed into the pasting player's chat

Tried making it separate from the IsAllowed function, because it's not a black**list**, but potentially dynamic