### PR TITLE
Add "strict" dupe mode

### DIFF
--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -809,6 +809,8 @@ local function reportmodel(ply, model)
 	net.Send(ply)
 end
 
+local strictConvar = GetConVar("AdvDupe2_Strict")
+
 --[[
 	Name: GenericDuplicatorFunction
 	Desc: Override the default duplicator's GenericDuplicatorFunction function
@@ -842,7 +844,9 @@ local function GenericDuplicatorFunction(data, Player)
 	Entity:Activate()
 	DoGenericPhysics(Entity, data, Player)
 
-	table.Add(Entity:GetTable(), data)
+	if (not strictConvar:GetBool()) then
+		table.Add(Entity:GetTable(), data)
+	end
 	return Entity
 end
 

--- a/lua/autorun/server/advdupe2_sv_init.lua
+++ b/lua/autorun/server/advdupe2_sv_init.lua
@@ -44,6 +44,7 @@ CreateConVar("AdvDupe2_SpawnRate", "1", {FCVAR_ARCHIVE})
 CreateConVar("AdvDupe2_MaxFileSize", "200", {FCVAR_ARCHIVE})
 CreateConVar("AdvDupe2_MaxEntities", "0", {FCVAR_ARCHIVE})
 CreateConVar("AdvDupe2_MaxConstraints", "0", {FCVAR_ARCHIVE})
+CreateConVar("AdvDupe2_Strict", "0", {FCVAR_ARCHIVE}, "Prevents entities from being duped with unauthorized data. Can fix certain exploits at the cost of some entities potentially duping incorrectly")
 
 CreateConVar("AdvDupe2_MaxContraptionEntities", "10", {FCVAR_ARCHIVE})
 CreateConVar("AdvDupe2_MaxContraptionConstraints", "15", {FCVAR_ARCHIVE})
@@ -60,28 +61,28 @@ CreateConVar("AdvDupe2_MapFileName", "", {FCVAR_ARCHIVE})
 local function PasteMap()
 	if(GetConVarString("AdvDupe2_LoadMap")=="0")then return end
 	local filename = GetConVarString("AdvDupe2_MapFileName")
-	
+
 	if(not filename or filename == "")then
 		print("[AdvDupe2Notify]\tInvalid file name to loap map save.")
 		return
 	end
-	
+
 	if(not file.Exists("advdupe2_maps/"..filename..".txt", "DATA"))then
 		print("[AdvDupe2Notify]\tFile does not exist for a map save.")
 		return
 	end
-	
+
 	local map = file.Read("advdupe2_maps/"..filename..".txt")
-	local success,dupe,info,moreinfo = AdvDupe2.Decode(map) 
+	local success,dupe,info,moreinfo = AdvDupe2.Decode(map)
 	if not success then
 		print("[AdvDupe2Notify]\tCould not open map save "..dupe)
 		return
-	end	
-	
+	end
+
 	local Tab = {Entities=dupe["Entities"], Constraints=dupe["Constraints"], HeadEnt=dupe["HeadEnt"]}
 	local Entities = AdvDupe2.duplicator.Paste(nil, table.Copy(Tab.Entities), Tab.Constraints, nil, nil, Tab.HeadEnt.Pos, true)
 	local maptype = GetConVarString("AdvDupe2_LoadMap")
-	
+
 	if(maptype=="1")then
 		local PhysObj
 		for k,v in pairs(Entities) do
@@ -111,7 +112,7 @@ local function PasteMap()
 			end
 		end
 	end
-	
+
 	print("[AdvDupe2Notify]\tMap save pasted.")
 end
 hook.Add("InitPostEntity", "AdvDupe2_PasteMap", PasteMap)
@@ -125,4 +126,3 @@ include( "advdupe2/sh_codec.lua" )
 include( "advdupe2/sv_misc.lua" )
 include( "advdupe2/sv_file.lua" )
 include( "advdupe2/sv_ghost.lua" )
-

--- a/lua/autorun/server/advdupe2_sv_init.lua
+++ b/lua/autorun/server/advdupe2_sv_init.lua
@@ -44,7 +44,7 @@ CreateConVar("AdvDupe2_SpawnRate", "1", {FCVAR_ARCHIVE})
 CreateConVar("AdvDupe2_MaxFileSize", "200", {FCVAR_ARCHIVE})
 CreateConVar("AdvDupe2_MaxEntities", "0", {FCVAR_ARCHIVE})
 CreateConVar("AdvDupe2_MaxConstraints", "0", {FCVAR_ARCHIVE})
-CreateConVar("AdvDupe2_Strict", "0", {FCVAR_ARCHIVE}, "Prevents entities from being duped with unauthorized data. Can fix certain exploits at the cost of some entities potentially duping incorrectly")
+CreateConVar("AdvDupe2_Strict", "1", {FCVAR_ARCHIVE}, "Prevents entities from being duped with unauthorized data. Can fix certain exploits at the cost of some entities potentially duping incorrectly")
 
 CreateConVar("AdvDupe2_MaxContraptionEntities", "10", {FCVAR_ARCHIVE})
 CreateConVar("AdvDupe2_MaxContraptionConstraints", "15", {FCVAR_ARCHIVE})


### PR DESCRIPTION
This pull request adds a `AdvDupe2_Strict` (0 by default) convar that makes it so the generic duplicator function doesn't merge the entity table

Merging the entire entity table allows clients to add any arbitrary key/value pairs to any entity that doesn't have a proper factory function. This can lead to a variety of exploits, such as:
* Spawning weapons with edited stats
* Breaking limit management mods (for example WUMA)
* Breaking any other addon that stores things in entity tables

Things that break with "strict" mode enabled:
* *None?* It ran 100% bug free on my server with wiremod, starfall, glide, etc. I guess it *can* break some old addons that rely on this behavior, but those can be fixed by defining a proper factory function for them

Further improvements:
* Write a better description for the convar
* It still copies the entire entity table when copying an entity, so clients can still see everything that was defined on the server-side when copying the entity, which might be exploitable
* GMod's generic NPC duplicator function still merges the entity table (*sigh*)