### PR TITLE
Allow duplicating an entity with an invalid PhysObj

### DIFF
--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -114,7 +114,7 @@ end
 ---------------------------------------------------------]]
 
 function AdvDupe2.duplicator.IsCopyable(Ent)
-	return not Ent.DoNotDuplicate and duplicator.IsAllowed(Ent:GetClass()) and IsValid(Ent:GetPhysicsObject())
+	return not Ent.DoNotDuplicate and duplicator.IsAllowed(Ent:GetClass())
 end
 
 local function CopyEntTable(Ent, Offset)


### PR DESCRIPTION
A regular duplicator allows the same thing and it doesn't cause any problems. Made this PR to solve compatibility with addons like [Half-Life 2 Tools](https://steamcommunity.com/sharedfiles/filedetails/?id=104619813&searchtext=hl2+tools)