### PR TITLE
Fix NULL errors

### DIFF
--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -114,7 +114,7 @@ end
 ---------------------------------------------------------]]
 
 function AdvDupe2.duplicator.IsCopyable(Ent)
-	return not Ent.DoNotDuplicate and duplicator.IsAllowed(Ent:GetClass()) and IsValid(Ent:GetPhysicsObject())
+	return IsValid(Ent) and not Ent.DoNotDuplicate and duplicator.IsAllowed(Ent:GetClass()) and IsValid(Ent:GetPhysicsObject())
 end
 
 local function CopyEntTable(Ent, Offset)


### PR DESCRIPTION
Fixes:
```
- Tried to use a NULL entity!
1. GetClass - [C]:-1
 2. IsCopyable - addons/advdupe2-master/lua/advdupe2/sv_clipboard.lua:117
  3. CopyEntTable - addons/advdupe2-master/lua/advdupe2/sv_clipboard.lua:122
   4. RecursiveCopy - addons/advdupe2-master/lua/advdupe2/sv_clipboard.lua:385
    5. RecursiveCopy - addons/advdupe2-master/lua/advdupe2/sv_clipboard.lua:432
     6. RecursiveCopy - addons/advdupe2-master/lua/advdupe2/sv_clipboard.lua:410
      7. RecursiveCopy - addons/advdupe2-master/lua/advdupe2/sv_clipboard.lua:420
       8. RecursiveCopy - addons/advdupe2-master/lua/advdupe2/sv_clipboard.lua:410
        9. Copy - addons/advdupe2-master/lua/advdupe2/sv_clipboard.lua:440
         10. RightClick - addons/advdupe2-master/lua/weapons/gmod_tool/stools/advdupe2.lua:325
          11. <unknown> - gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua:265
```
I don't know why this happens, but it will also make this function more reliable anyway