### PR TITLE
Fix NULL + speed up function

### DIFF
--- a/lua/weapons/gmod_tool/stools/advdupe2.lua
+++ b/lua/weapons/gmod_tool/stools/advdupe2.lua
@@ -160,7 +160,7 @@ if(SERVER) then
 		local EntTable = {}
 
 		for _, ent in ipairs(ents.FindInBox(min, max)) do
-			if not PPCheck(ply, ent) then
+			if PPCheck(ply, ent) then
 				EntTable[ent:EntIndex()] = ent
 			end
 		end


### PR DESCRIPTION
ents.Iterator is unstable on the client and for some unexplained reason can very rarely contain NULL entities. So I replaced it with ents.FindInBox which is also faster
Fixes:
```
- Tried to use a NULL entity!
1. GetPos - [C]:-1
 2. FindInBox - addons/advdupe2-master/lua/weapons/gmod_tool/stools/advdupe2.lua:1730
  3. <unknown> - addons/advdupe2-master/lua/weapons/gmod_tool/stools/advdupe2.lua:1771
   4. <unknown> - addons/hook-library-master/lua/includes/modules/hook.lua:313
```