### PR TITLE
Again block entities with invalid physics object

### DIFF
--- a/lua/advdupe2/cl_ghost.lua
+++ b/lua/advdupe2/cl_ghost.lua
@@ -341,12 +341,9 @@ function AdvDupe2.UpdateGhosts(force)
 
 		for k, ghost in ipairs(AdvDupe2.GhostEntities) do
 			local phys = ghost.Phys
-
-			if phys then
-				local pos, ang = LocalToWorld(phys.Pos, phys.Angle, originpos, originang)
-				ghost:SetPos(pos)
-				ghost:SetAngles(ang)
-			end
+			local pos, ang = LocalToWorld(phys.Pos, phys.Angle, originpos, originang)
+			ghost:SetPos(pos)
+			ghost:SetAngles(ang)
 		end
 
 	end

--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -114,7 +114,7 @@ end
 ---------------------------------------------------------]]
 
 function AdvDupe2.duplicator.IsCopyable(Ent)
-	return not Ent.DoNotDuplicate and duplicator.IsAllowed(Ent:GetClass())
+	return not Ent.DoNotDuplicate and duplicator.IsAllowed(Ent:GetClass()) and IsValid(Ent:GetPhysicsObject())
 end
 
 local function CopyEntTable(Ent, Offset)
@@ -201,7 +201,6 @@ local function CopyEntTable(Ent, Offset)
 		end
 	end
 
-	if not Tab.PhysicsObjects[0] then Tab.PhysicsObjects[0] = {Angle = Ent:GetAngles()} end
 	Tab.PhysicsObjects[0].Pos = Tab.Pos - Offset
 
 	Tab.Pos = nil
@@ -435,11 +434,7 @@ local function Copy(ply, Ent, EntTable, ConstraintTable, Offset)
 		end
 
 		for k, v in pairs(EntData.PhysicsObjects) do
-			local phys = Ent:GetPhysicsObjectNum(k)
-
-			if IsValid(phys) then
-				phys:EnableMotion(v.Frozen)
-			end
+			Ent:GetPhysicsObjectNum(k):EnableMotion(v.Frozen)
 		end
 	end
 	RecursiveCopy(Ent)
@@ -464,11 +459,7 @@ function AdvDupe2.duplicator.AreaCopy(ply, Entities, Offset, CopyOutside)
 
 			if (not constraint.HasConstraints(Ent)) then
 				for k, v in pairs(EntTable[Ent:EntIndex()].PhysicsObjects) do
-					local phys = Ent:GetPhysicsObjectNum(k)
-
-					if IsValid(phys) then
-						phys:EnableMotion(v.Frozen)
-					end
+					Ent:GetPhysicsObjectNum(k):EnableMotion(v.Frozen)
 				end
 			else
 				for k, v in pairs(Ent.Constraints) do


### PR DESCRIPTION
This causes area copy to copy things it shouldn't. I don't see any obvious way to fix #514 any other way.