### PR TITLE
Fix nil error

### DIFF
--- a/lua/weapons/gmod_tool/stools/advdupe2.lua
+++ b/lua/weapons/gmod_tool/stools/advdupe2.lua
@@ -853,7 +853,10 @@ if(SERVER) then
 			if(not file.IsDir("advdupe2_maps", "DATA")) then
 				file.CreateDir("advdupe2_maps")
 			end
-			file.Write("advdupe2_maps/"..args[1]..".txt", data)
+
+			local savename = args[1] or game.GetMap() .. "_" .. util.DateStamp()
+			file.Write("advdupe2_maps/" .. savename .. ".txt", data)
+
 			AdvDupe2.Notify(ply, "Map save, saved successfully.")
 		end)
 	end)


### PR DESCRIPTION
Fixes:
```
] AdvDupe2_SaveMap

[Advanced Duplicator 2] lua/weapons/gmod_tool/stools/advdupe2.lua:856: attempt to concatenate a nil value
  1. callback - lua/weapons/gmod_tool/stools/advdupe2.lua:856
   2. Encode - lua/advdupe2/sh_codec.lua:374
    3. unknown - lua/weapons/gmod_tool/stools/advdupe2.lua:848
     4. unknown - lua/includes/modules/concommand.lua:54
```