### PR TITLE
Fixed/improved map save

### DIFF
--- a/lua/advdupe2/cl_file.lua
+++ b/lua/advdupe2/cl_file.lua
@@ -1,13 +1,3 @@
-local invalidCharacters = { "\"", ":"}
-function AdvDupe2.SanitizeFilename(filename)
-	for i=1, #invalidCharacters do
-		filename = string.gsub(filename, invalidCharacters[i], "_")
-	end
-	filename = string.gsub(filename, "%s+", " ")
-
-	return filename
-end
-
 function AdvDupe2.ReceiveFile(data, autoSave)
 	AdvDupe2.RemoveProgressBar()
 	if not data then

--- a/lua/advdupe2/sh_codec.lua
+++ b/lua/advdupe2/sh_codec.lua
@@ -48,14 +48,8 @@ function AdvDupe2.GenerateDupeStamp(ply)
 	return stamp
 end
 
-local invalidCharacters = {"\"", ":"}
-
 function AdvDupe2.SanitizeFilename(filename)
-	for i = 1, #invalidCharacters do
-		filename = string.gsub(filename, invalidCharacters[i], "_")
-	end
-
-	return string.gsub(filename, "%s+", " ")
+	return string.gsub(string.gsub(filename, "[\":]", "_"), "%s+", " ")
 end
 
 local function makeInfo(tbl)

--- a/lua/advdupe2/sh_codec.lua
+++ b/lua/advdupe2/sh_codec.lua
@@ -48,6 +48,16 @@ function AdvDupe2.GenerateDupeStamp(ply)
 	return stamp
 end
 
+local invalidCharacters = {"\"", ":"}
+
+function AdvDupe2.SanitizeFilename(filename)
+	for i = 1, #invalidCharacters do
+		filename = string.gsub(filename, invalidCharacters[i], "_")
+	end
+
+	return string.gsub(filename, "%s+", " ")
+end
+
 local function makeInfo(tbl)
 	local info = ""
 	for k, v in pairs(tbl) do

--- a/lua/autorun/server/advdupe2_sv_init.lua
+++ b/lua/autorun/server/advdupe2_sv_init.lua
@@ -67,12 +67,12 @@ local function PasteMap()
 		return
 	end
 
-	if(not file.Exists("advdupe2_maps/"..filename..".txt", "DATA"))then
+	if(not file.Exists("advdupe2/"..filename..".txt", "DATA"))then
 		print("[AdvDupe2Notify]\tFile does not exist for a map save.")
 		return
 	end
 
-	local map = file.Read("advdupe2_maps/"..filename..".txt")
+	local map = file.Read("advdupe2/"..filename..".txt")
 	local success,dupe,info,moreinfo = AdvDupe2.Decode(map)
 	if not success then
 		print("[AdvDupe2Notify]\tCould not open map save "..dupe)

--- a/lua/weapons/gmod_tool/stools/advdupe2.lua
+++ b/lua/weapons/gmod_tool/stools/advdupe2.lua
@@ -815,12 +815,13 @@ if(SERVER) then
 	end)
 
 	concommand.Add("AdvDupe2_SaveMap", function(ply, cmd, args)
-		if(not ply:IsAdmin()) then
+		if not ply:IsSuperAdmin() then
 			AdvDupe2.Notify(ply, "You do not have permission to this function.", NOTIFY_ERROR)
 			return
 		end
 
 		local Entities = {}
+
 		for _, v in ents.Iterator() do
 			if not v:CreatedByMap() and AdvDupe2.duplicator.IsCopyable(v) then
 				Entities[v:EntIndex()] = v
@@ -828,34 +829,34 @@ if(SERVER) then
 		end
 
 		local _, HeadEnt = next(Entities)
-		if not HeadEnt then return end
+		if not HeadEnt then AdvDupe2.Notify(ply, "There is nothing to save!", NOTIFY_ERROR) return end
 
-		local Tab = {Entities={}, Constraints={}, HeadEnt={}, Description=""}
+		local Tab = {Entities = {}, Constraints = {}, HeadEnt = {}, Description = ""}
 		Tab.HeadEnt.Index = HeadEnt:EntIndex()
 		Tab.HeadEnt.Pos = HeadEnt:GetPos()
 
 		local WorldTrace = util.TraceLine({
 			mask   = MASK_NPCWORLDSTATIC,
-			start  = Tab.HeadEnt.Pos + Vector(0,0,1),
-			endpos = Tab.HeadEnt.Pos - Vector(0,0,50000)
+			start  = Tab.HeadEnt.Pos + Vector(0, 0, 1),
+			endpos = Tab.HeadEnt.Pos - Vector(0, 0, 50000)
 		})
 
 		Tab.HeadEnt.Z = WorldTrace.Hit and math.abs(Tab.HeadEnt.Pos.Z - WorldTrace.HitPos.Z) or 0
 		Tab.Entities, Tab.Constraints = AdvDupe2.duplicator.AreaCopy(ply, Entities, Tab.HeadEnt.Pos, true)
 		Tab.Constraints = GetSortedConstraints(ply, Tab.Constraints)
-
 		Tab.Map = true
-		AdvDupe2.Encode( Tab, AdvDupe2.GenerateDupeStamp(ply), function(data)
+
+		AdvDupe2.Encode(Tab, AdvDupe2.GenerateDupeStamp(ply), function(data)
 			if #data > AdvDupe2.MaxDupeSize then
-				AdvDupe2.Notify(ply, "Copied duplicator filesize is too big!",NOTIFY_ERROR)
-				return 
-			end
-			if(not file.IsDir("advdupe2_maps", "DATA")) then
-				file.CreateDir("advdupe2_maps")
+				AdvDupe2.Notify(ply, "Copied duplicator filesize is too big!", NOTIFY_ERROR)
+				return
 			end
 
-			local savename = args[1] or game.GetMap() .. "_" .. util.DateStamp()
-			file.Write("advdupe2_maps/" .. savename .. ".txt", data)
+			local map = game.GetMap()
+			file.CreateDir("advdupe2/maps/" .. map)
+
+			local savename = args[1] or util.DateStamp()
+			file.Write("advdupe2/maps/" .. map .. "/" .. savename .. ".txt", data)
 
 			AdvDupe2.Notify(ply, "Map save, saved successfully.")
 		end)

--- a/lua/weapons/gmod_tool/stools/advdupe2.lua
+++ b/lua/weapons/gmod_tool/stools/advdupe2.lua
@@ -1647,7 +1647,6 @@ if(CLIENT) then
 			btn2:SizeToContents()
 			btn2:SetToolTip("Save Map")
 			btn2.DoClick = 	function()
-				if(txtbox2:GetValue()=="") then return end
 				RunConsoleCommand("AdvDupe2_SaveMap", txtbox2:GetValue())
 			end
 			txtbox2.OnEnter = function()

--- a/lua/weapons/gmod_tool/stools/advdupe2.lua
+++ b/lua/weapons/gmod_tool/stools/advdupe2.lua
@@ -855,7 +855,7 @@ if(SERVER) then
 			local map = game.GetMap()
 			file.CreateDir("advdupe2/maps/" .. map)
 
-			local savename = args[1] or util.DateStamp()
+			local savename = AdvDupe2.SanitizeFilename(args[1]) or util.DateStamp()
 			file.Write("advdupe2/maps/" .. map .. "/" .. savename .. ".txt", data)
 
 			AdvDupe2.Notify(ply, "Map save, saved successfully.")

--- a/lua/weapons/gmod_tool/stools/advdupe2.lua
+++ b/lua/weapons/gmod_tool/stools/advdupe2.lua
@@ -855,7 +855,7 @@ if(SERVER) then
 			local map = game.GetMap()
 			file.CreateDir("advdupe2/maps/" .. map)
 
-			local savename = AdvDupe2.SanitizeFilename(args[1]) or util.DateStamp()
+			local savename = AdvDupe2.SanitizeFilename(args[1] and #args[1] > 0 and args[1] or util.DateStamp())
 			file.Write("advdupe2/maps/" .. map .. "/" .. savename .. ".txt", data)
 
 			AdvDupe2.Notify(ply, "Map save, saved successfully.")


### PR DESCRIPTION
Completes https://github.com/wiremod/advdupe2/pull/518, adds a new error message if there is nothing to save on the map, and also sorts all saves in the `advdupe2/maps/MAP_NAME/SAVE_NAME` folder so that they can be read directly from the duplicator