### PR TITLE
Added GM:OnDuplicated(ent, entDupeTable), GMod PR

### DIFF
--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -1190,6 +1190,7 @@ function AdvDupe2.duplicator.Paste(Player, EntityList, ConstraintList, Position,
 			Ent.EntityMods = table.Copy(v.EntityMods)
 			Ent.PhysicsObjects = table.Copy(v.PhysicsObjects)
 			if (v.CollisionGroup) then Ent:SetCollisionGroup(v.CollisionGroup) end
+			hook.Run("OnDuplicated", Ent, v)
 			if (Ent.OnDuplicated) then Ent:OnDuplicated(v) end
 			ApplyEntityModifiers(Player, Ent)
 			ApplyBoneModifiers(Player, Ent)
@@ -1362,6 +1363,7 @@ local function AdvDupe2_Spawn()
 			if (IsValid(Phys)) then Phys:EnableMotion(false) end
 			if (not Queue.DisableProtection) then Ent:SetNotSolid(true) end
 			if (v.CollisionGroup) then Ent:SetCollisionGroup(v.CollisionGroup) end
+			hook.Run("OnDuplicated", Ent, v)
 			if (Ent.OnDuplicated) then Ent:OnDuplicated(v) end
 		elseif (Ent == false) then
 			Ent = nil


### PR DESCRIPTION
In adjacent to: https://github.com/Facepunch/garrysmod/pull/2408

Works like `ENTITY:OnDuplicated(ent, entDupeTable)` but doesn't require adding/detouring `ent.OnDuplicated` on `OnEntityCreated` calls for addon-foreign entities.

This adds a easy way to add generic logic early to the duplication life cycle. It is called a way before `duplicator.RegisterEntityModifier()` added callers are being iterated. The new hook also reduces the risk of conflicts caused by detours of pre-existing `ent.OnDuplicated` code.

Test script:
```lua
if SERVER then
    hook.Add("OnDuplicated", "Test", function(ent, entTable)
        print(ent)
        PrintTable(entTable)
    end)
end
```