### PR TITLE
Fix unfreezing issues caused by #522

### DIFF
--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -802,7 +802,7 @@ end
 local function DoGenericPhysics(entity, data, ply)
 	if not data.PhysicsObjects then return end
 
-	for bone, args in ipairs(data.PhysicsObjects) do
+	for bone, args in pairs(data.PhysicsObjects) do
 		local phys = entity:GetPhysicsObjectNum(bone)
 
 		if IsValid(phys) then


### PR DESCRIPTION
Fixes props being unfreezable after pasting. Bone IDs can be 0, so `ipairs` won't iterate over them, causing props to not get added to the frozen object list.