### PR TITLE
Trim all trailing whitespace + convert existing spaces to tabs

### DIFF
--- a/lua/advdupe2/file_browser.lua
+++ b/lua/advdupe2/file_browser.lua
@@ -72,9 +72,9 @@ local function NarrowHistory(txt, last)
 end
 
 local function tableSortNodes(tbl)
-    for k, v in ipairs(tbl) do tbl[k] = {string.lower(v.Label:GetText()), v} end
-    table.sort(tbl, function(a,b) return a[1]<b[1] end)
-    for k, v in ipairs(tbl) do tbl[k] = v[2] end
+	for k, v in ipairs(tbl) do tbl[k] = {string.lower(v.Label:GetText()), v} end
+	table.sort(tbl, function(a,b) return a[1]<b[1] end)
+	for k, v in ipairs(tbl) do tbl[k] = v[2] end
 end
 
 local BROWSERPNL = {}

--- a/lua/advdupe2/sh_codec_legacy.lua
+++ b/lua/advdupe2/sh_codec_legacy.lua
@@ -67,7 +67,7 @@ decode_types_v2 = {
 		error("expected value, got terminator\n")
 	end,
 	[2	] = function() -- table
-		
+
 		m = find(str, "\1", pos)
 		if m then
 			w = sub(str, pos+1, m-1)
@@ -75,10 +75,10 @@ decode_types_v2 = {
 		else
 			error("expected table identifier, got EOF\n")
 		end
-		
+
 		local t = {}
 		tables[w] = t
-		
+
 		while true do
 			if byte(str, pos+1) == 1 then
 				pos = pos + 1
@@ -89,7 +89,7 @@ decode_types_v2 = {
 		end
 	end,
 	[3	] = function() -- array
-		
+
 		m = find(str, "\1", pos)
 		if m then
 			w = sub(str, pos+1, m-1)
@@ -97,11 +97,11 @@ decode_types_v2 = {
 		else
 			error("expected table identifier, got EOF\n")
 		end
-		
+
 		local t, i = {}, 1
-		
+
 		tables[w] = t
-		
+
 		while true do
 			if byte(str,pos+1) == 1 then
 				pos = pos+1
@@ -167,13 +167,13 @@ decode_types_v2 = {
 			error("expected table identifier, got EOF\n")
 		end
 		tblref = tables[w]
-		
+
 		if tblref then
 			return tblref
 		else
 			error(format("table identifier %s points to nil\n", w))
 		end
-		
+
 	end
 }
 
@@ -289,16 +289,16 @@ local function lzwDecode(encoded)
 	for i = 0, 255 do
 		dictionary[i] = char(i)
 	end
-	
+
 	local pos = 2
 	local decompressed = {}
 	local decompressed_length = 1
-	
+
 	local index = byte(encoded)
 	local word = dictionary[index]
-	
+
 	decompressed[decompressed_length] = dictionary[index]
-	
+
 	local entry
 	local encoded_length = #encoded
 	local firstbyte --of an index
@@ -307,11 +307,11 @@ local function lzwDecode(encoded)
 		if firstbyte > 252 then --now we know it's a length indicator for a multibyte index
 			index = 0
 			firstbyte = 256 - firstbyte
-			
+
 			--[[if pos+firstbyte > encoded_length then	--will test for performance impact
 				error("expected index got EOF")
 			end]]
-			
+
 			for i = pos+firstbyte, pos+1, -1 do
 				index = bit.bor(bit.lshift(index, 8), byte(encoded,i))
 			end
@@ -335,13 +335,13 @@ end
 local invcodes = {[2]={[0]="\254"},[5]={[22]="\1",[11]="\2"},[6]={[13]="\7",[35]="\6",[37]="\5",[58]="\3",[31]="\8",[9]="\13",[51]="\9",[55]="\10",[57]="\4",[59]="\15"},[7]={[1]="\14",[15]="\16",[87]="\31",[89]="\30",[62]="\26",[17]="\27",[97]="\19",[19]="\43",[10]="\12",[39]="\33",[41]="\24",[82]="\40",[3]="\32",[46]="\41",[47]="\38",[94]="\25",[65]="\23",[50]="\39",[26]="\11",[7]="\28",[33]="\18",[61]="\17",[25]="\42"},[8]={[111]="\101",[162]="\29",[2]="\34",[133]="\21",[142]="\36",[5]="\20",[21]="\37",[170]="\44",[130]="\22",[66]="\35"},[9]={[241]="\121",[361]="\104",[365]="\184",[125]="\227",[373]="\198",[253]="\117",[381]="\57",[270]="\49",[413]="\80",[290]="\47",[294]="\115",[38]="\112",[429]="\74",[433]="\0",[437]="\48",[158]="\183",[453]="\107",[166]="\111",[469]="\182",[477]="\241",[45]="\86",[489]="\69",[366]="\100",[497]="\61",[509]="\76",[49]="\53",[390]="\78",[279]="\196",[283]="\70",[414]="\98",[53]="\55",[422]="\109",[233]="\79",[349]="\89",[369]="\52",[14]="\105",[238]="\56",[319]="\162",[323]="\83",[327]="\63",[458]="\65",[335]="\231",[339]="\225",[337]="\114",[347]="\193",[493]="\139",[23]="\209",[359]="\250",[490]="\68",[42]="\54",[63]="\91",[286]="\97",[254]="\50",[510]="\108",[109]="\73",[67]="\103",[255]="\122",[69]="\170",[70]="\110",[407]="\176",[411]="\119",[110]="\120",[83]="\146",[149]="\163",[151]="\224",[85]="\51",[155]="\177",[79]="\251",[27]="\118",[447]="\159",[451]="\228",[455]="\175",[383]="\174",[463]="\243",[467]="\157",[173]="\210",[475]="\167",[177]="\84",[90]="\45",[487]="\206",[93]="\226",[495]="\245",[207]="\64",[127]="\147",[191]="\155",[511]="\153",[195]="\208",[197]="\85",[199]="\178",[181]="\82",[102]="\116",[103]="\71",[285]="\144",[105]="\102",[211]="\199",[213]="\123",[301]="\66",[305]="\46",[219]="\137",[81]="\67",[91]="\88",[157]="\130",[325]="\95",[29]="\58",[231]="\201",[117]="\99",[341]="\222",[237]="\77",[239]="\211",[71]="\223"},[10]={[710]="\149",[245]="\60",[742]="\172",[774]="\81",[134]="\151",[917]="\145",[274]="\216",[405]="\242",[146]="\194",[838]="\246",[298]="\248",[870]="\189",[1013]="\150",[894]="\190",[326]="\244",[330]="\166",[334]="\217",[465]="\179",[346]="\59",[354]="\180",[966]="\212",[974]="\143",[370]="\148",[998]="\154",[625]="\138",[382]="\161",[194]="\141",[198]="\126",[402]="\96",[206]="\185",[586]="\129",[721]="\187",[610]="\135",[618]="\181",[626]="\72",[226]="\62",[454]="\127",[658]="\113",[462]="\164",[234]="\214",[474]="\140",[242]="\106",[714]="\188",[730]="\87",[498]="\237",[746]="\125",[754]="\229",[786]="\128",[202]="\93",[18]="\255",[810]="\173",[846]="\131",[74]="\192",[842]="\142",[977]="\252",[858]="\235",[78]="\134",[874]="\234",[882]="\90",[646]="\92",[1006]="\160",[126]="\165",[914]="\221",[718]="\94",[738]="\238",[638]="\197",[482]="\230",[34]="\220",[962]="\133",[6]="\213",[706]="\219",[986]="\171",[994]="\233",[866]="\200",[1010]="\247",[98]="\169",[518]="\236",[494]="\207",[230]="\205",[542]="\191",[501]="\202",[530]="\203",[450]="\204",[209]="\158",[106]="\186",[590]="\136",[218]="\232",[733]="\124",[309]="\168",[221]="\152",[757]="\240",[113]="\215",[114]="\156",[362]="\239",[486]="\132",[358]="\249",[262]="\75",[30]="\218",[821]="\195",[546]="\253"}}
 
 local function huffmanDecode(encoded)
-	
+
 	local h1,h2,h3 = byte(encoded, 1, 3)
-	
+
 	if (not h3) or (#encoded < 4) then
 		error("invalid input")
 	end
-	
+
 	local original_length = bit.bor(bit.lshift(h3,16), bit.lshift(h2,8), h1)
 	local encoded_length = #encoded+1
 	local decoded = {}
@@ -352,7 +352,7 @@ local function huffmanDecode(encoded)
 	local code_len = 2
 	local temp
 	local pos = 4
-	
+
 	while decoded_length < original_length do
 		if code_len <= buffer_length then
 			temp = invcodes[code_len]
@@ -378,15 +378,15 @@ local function huffmanDecode(encoded)
 			end
 		end
 	end
-	
+
 	return concat(decoded)
 end
 
 local function invEscapeSub(str)
 	local escseq,body = match(str,"^(.-)\n(.-)$")
-	
+
 	if not escseq then error("invalid input") end
-	
+
 	return gsub(body,escseq,"\26")
 end
 
@@ -394,9 +394,9 @@ local dictionary
 local subtables
 
 local function deserializeChunk(chunk)
-	
+
 	local ctype,val = byte(chunk),sub(chunk,3)
-	
+
 	if     ctype == 89 then return dictionary[ val ]
 	elseif ctype == 86 then
 		local a,b,c = match(val,"^(.-),(.-),(.+)$")
@@ -404,7 +404,7 @@ local function deserializeChunk(chunk)
 	elseif ctype == 65 then
 		local a,b,c = match(val,"^(.-),(.-),(.+)$")
 		return Angle( tonumber(a), tonumber(b), tonumber(c) )
-	elseif ctype == 84 then 
+	elseif ctype == 84 then
 		local t = {}
 		local tv = subtables[val]
 		if not tv then
@@ -414,34 +414,34 @@ local function deserializeChunk(chunk)
 		tv[#tv+1] = t
 		return t
 	elseif ctype == 78 then return tonumber(val)
-	elseif ctype == 83 then return gsub(sub(val,2,-2),"»",";")
+	elseif ctype == 83 then return gsub(sub(val,2,-2),"ï¿½",";")
 	elseif ctype == 66 then return val == "t"
 	elseif ctype == 80 then return 1
 	end
-	
+
 	error(format("AD1 deserialization failed: invalid chunk (%u:%s)",ctype,val))
-	
+
 end
 
 local function deserializeAD1(dupestring)
-	
+
 	dupestring = dupestring:Replace("\r\n", "\n")
 	local header, extraHeader, dupeBlock, dictBlock = dupestring:match("%[Info%]\n(.+)\n%[More Information%]\n(.+)\n%[Save%]\n(.+)\n%[Dict%]\n(.+)")
-	
+
 	if not header then
 		error("unknown duplication format")
 	end
-	
+
 	local info = {}
 	for k,v in header:gmatch("([^\n:]+):([^\n]+)") do
 		info[k] = v
 	end
-		
+
 	local moreinfo = {}
 	for k,v in extraHeader:gmatch("([^\n:]+):([^\n]+)") do
 		moreinfo[k] = v
 	end
-	
+
 	dictionary = {}
 	for k,v in dictBlock:gmatch("(.-):\"(.-)\"\n") do
 		dictionary[k] = v
@@ -449,39 +449,39 @@ local function deserializeAD1(dupestring)
 
 	local dupe = {}
 	for key,block in dupeBlock:gmatch("([^\n:]+):([^\n]+)") do
-		
+
 		local tables = {}
 		subtables = {}
 		local head
-		
+
 		for id,chunk in block:gmatch('(%w+){(.-)}') do
-			
+
 			--check if this table is the trunk
 			if byte(id) == 72 then
 				id = sub(id,2)
 				head = id
 			end
-			
+
 			tables[id] = {}
-			
+
 			for kv in gmatch(chunk,'[^;]+') do
-				
+
 				local k,v = match(kv,'(.-)=(.+)')
-				
+
 				if k then
 					k = deserializeChunk( k )
 					v = deserializeChunk( v )
-					
+
 					tables[id][k] = v
 				else
 					v = deserializeChunk( kv )
 					local tid = tables[id]
 					tid[#tid+1]=v
 				end
-				
+
 			end
 		end
-		
+
 		--Restore table references
 		for id,tbls in pairs( subtables ) do
 			for _,tbl in pairs( tbls ) do
@@ -491,13 +491,13 @@ local function deserializeAD1(dupestring)
 				end
 			end
 		end
-		
+
 		dupe[key] = tables[ head ]
-		
+
 	end
-	
+
 	return dupe, info, moreinfo
-	
+
 end
 
 --seperates the header and body and converts the header to a table

--- a/lua/advdupe2/sv_file.lua
+++ b/lua/advdupe2/sv_file.lua
@@ -1,21 +1,21 @@
 --Save a file to the client
 local function SaveFile(ply, cmd, args)
 	if(not ply.AdvDupe2 or not ply.AdvDupe2.Entities or next(ply.AdvDupe2.Entities)==nil)then AdvDupe2.Notify(ply,"Duplicator is empty, nothing to save.", NOTIFY_ERROR) return end
-	if(not game.SinglePlayer() and CurTime()-(ply.AdvDupe2.FileMod or 0) < 0)then 
+	if(not game.SinglePlayer() and CurTime()-(ply.AdvDupe2.FileMod or 0) < 0)then
 		AdvDupe2.Notify(ply,"Cannot save at the moment. Please Wait...", NOTIFY_ERROR)
 		return
 	end
-	
+
 	if(ply.AdvDupe2.Pasting || ply.AdvDupe2.Downloading)then
 		AdvDupe2.Notify(ply,"Advanced Duplicator 2 is busy.",NOTIFY_ERROR)
-		return false 
+		return false
 	end
 
 	ply.AdvDupe2.FileMod = CurTime()+tonumber(GetConVarString("AdvDupe2_FileModificationDelay")+2)
-	
+
 	local name = string.Explode("/", args[1])
 	ply.AdvDupe2.Name = name[#name]
-	
+
 	net.Start("AdvDupe2_SetDupeInfo")
 		net.WriteString(ply.AdvDupe2.Name)
 		net.WriteString(ply:Nick())
@@ -26,7 +26,7 @@ local function SaveFile(ply, cmd, args)
 		net.WriteString(table.Count(ply.AdvDupe2.Entities))
 		net.WriteString(#ply.AdvDupe2.Constraints)
 	net.Send(ply)
-	
+
 	local Tab = {Entities = ply.AdvDupe2.Entities, Constraints = ply.AdvDupe2.Constraints, HeadEnt = ply.AdvDupe2.HeadEnt, Description=args[2]}
 
 	AdvDupe2.Encode( Tab, AdvDupe2.GenerateDupeStamp(ply), function(data)
@@ -55,12 +55,12 @@ end
 
 function AdvDupe2.LoadDupe(ply,success,dupe,info,moreinfo)
 	if(not IsValid(ply))then return end
-			
-	if not success then 
+
+	if not success then
 		AdvDupe2.Notify(ply,"Could not open "..dupe,NOTIFY_ERROR)
 		return
 	end
-			
+
 	if(not game.SinglePlayer())then
 		if(tonumber(GetConVarString("AdvDupe2_MaxConstraints"))~=0 and #dupe["Constraints"]>tonumber(GetConVarString("AdvDupe2_MaxConstraints")))then
 			AdvDupe2.Notify(ply,"Amount of constraints is greater than "..GetConVarString("AdvDupe2_MaxConstraints"),NOTIFY_ERROR)
@@ -86,7 +86,7 @@ function AdvDupe2.LoadDupe(ply,success,dupe,info,moreinfo)
 		for k,v in pairs(dupe["Entities"])do
 			Pos = nil
 			Ang = nil
-			if(v.SavedParentIdx)then 
+			if(v.SavedParentIdx)then
 				if(not v.BuildDupeInfo)then v.BuildDupeInfo = {} end
 				v.BuildDupeInfo.DupeParentID = v.SavedParentIdx
 				Pos = v.LocalPos*1
@@ -98,7 +98,7 @@ function AdvDupe2.LoadDupe(ply,success,dupe,info,moreinfo)
 				p.Angle = Ang or (p.LocalAngle*1)
 				p.LocalPos = nil
 				p.LocalAngle = nil
-				p.Frozen = not p.Frozen -- adv dupe 2 does this wrong way 
+				p.Frozen = not p.Frozen -- adv dupe 2 does this wrong way
 			end
 			v.LocalPos = nil
 			v.LocalAngle = nil
@@ -106,8 +106,8 @@ function AdvDupe2.LoadDupe(ply,success,dupe,info,moreinfo)
 
 		ply.AdvDupe2.Entities = dupe["Entities"]
 		ply.AdvDupe2.Constraints = dupe["Constraints"]
-		
-	else	
+
+	else
 		ply.AdvDupe2.Entities = dupe["Entities"]
 		ply.AdvDupe2.Constraints = dupe["Constraints"]
 		ply.AdvDupe2.HeadEnt = dupe["HeadEnt"]

--- a/lua/advdupe2/sv_misc.lua
+++ b/lua/advdupe2/sv_misc.lua
@@ -1,10 +1,10 @@
 --[[
 	Title: Miscellaneous
-	
+
 	Desc: Contains miscellaneous (serverside) things AD2 needs to function that don't fit anywhere else.
-	
+
 	Author: TB
-	
+
 	Version: 1.0
 ]]
 
@@ -22,7 +22,7 @@ local function SavePositions( Constraint )
 		if Constraint.BuildDupeInfo then return end
 		local BuildDupeInfo = {}
 		Constraint.BuildDupeInfo = BuildDupeInfo
-			
+
 		local Ent1, Ent2
 		if IsValid(Constraint.Ent) then
 			if Constraint.Ent:GetPhysicsObjectCount()>1 then
@@ -73,7 +73,7 @@ local function SavePositions( Constraint )
 					BuildDupeInfo.Ent2Ang = Bone:GetAngles()
 				end
 			end
-				
+
 		end
 
 	end

--- a/lua/autorun/netstream.lua
+++ b/lua/autorun/netstream.lua
@@ -87,7 +87,7 @@ local ReadStreamQueue = {
 				ErrorNoHalt("Receiving too many ReadStream requests!")
 				return
 			end
-			
+
 			for _, v in ipairs(queue) do
 				if v.identifier == stream.identifier then
 					ErrorNoHalt("Tried to start a new ReadStream for an already existing stream!")
@@ -323,7 +323,7 @@ function net.WriteStream(data, callback, dontcompress)
 
 	local stream = net.Stream.WriteStreams:Add(WritingDataItem(data, callback, compressed))
 	if not stream then return end
-	
+
 	--print("WriteStream", #stream.chunks, stream.identifier, compressed)
 	net.WriteUInt(#stream.chunks, 32)
 	net.WriteUInt(stream.identifier, 32)
@@ -347,7 +347,7 @@ function net.ReadStream(ply, callback)
 	if not isfunction(callback) then
 		error("bad argument #2 to 'ReadStream' (function expected, got " .. type(callback) .. ")", 2)
 	end
-	
+
 	local numchunks = net.ReadUInt(32)
 	if numchunks == nil then
 		return

--- a/lua/entities/gmod_contr_spawner/init.lua
+++ b/lua/entities/gmod_contr_spawner/init.lua
@@ -1,10 +1,10 @@
---[[	
+--[[
 	Title: Adv. Dupe 2 Contraption Spawner
-	
+
 	Desc: A mobile duplicator
-	
+
 	Author: TB
-	
+
 	Version: 1.0
 ]]
 
@@ -22,18 +22,18 @@ function ENT:Initialize()
 	self.Entity:PhysicsInit( SOLID_VPHYSICS )
 	self.Entity:SetCollisionGroup( COLLISION_GROUP_WORLD )
 	self.Entity:DrawShadow( false )
-	
+
 	local phys = self.Entity:GetPhysicsObject()
 	if phys:IsValid() then
 		phys:Wake()
 	end
-	
+
 	self.UndoList = {}
 	self.Ghosts = {}
 
 	self.SpawnLastValue = 0
 	self.UndoLastValue = 0
-	
+
 	self.LastSpawnTime = 0
 	self.DupeName = ""
 	self.CurrentPropCount = 0
@@ -45,8 +45,8 @@ function ENT:Initialize()
 end
 
 /*-----------------------------------------------------------------------*
- * Sets options for this spawner
- *-----------------------------------------------------------------------*/
+* Sets options for this spawner
+*-----------------------------------------------------------------------*/
 function ENT:SetOptions(ply, delay, undo_delay, key, undo_key, disgrav, disdrag, addvel, hideprops )
 
 	self.delay = delay
@@ -93,31 +93,31 @@ function ENT:AddGhosts()
 				v.BuildDupeInfo.PhysicsObjects = table.Copy(v.PhysicsObjects)
 				Phys = EntTable.PhysicsObjects[0]
 			end
-			
+
 			GhostEntity = nil
-			
+
 			if(EntTable.Model==nil || !util.IsValidModel(EntTable.Model)) then EntTable.Model="models/error.mdl" end
-			
+
 			if ( EntTable.Model:sub( 1, 1 ) == "*" ) then
 				GhostEntity = ents.Create( "func_physbox" )
 			else
 				GhostEntity = ents.Create( "gmod_ghost" )
 			end
-			
+
 			// If there are too many entities we might not spawn..
 			if ( !GhostEntity || GhostEntity == NULL ) then return end
-			
+
 			duplicator.DoGeneric( GhostEntity, EntTable )
-			
+
 			GhostEntity:Spawn()
-			
+
 			GhostEntity:DrawShadow( false )
 			GhostEntity:SetMoveType( MOVETYPE_NONE )
 			GhostEntity:SetSolid( SOLID_VPHYSICS );
 			GhostEntity:SetNotSolid( true )
 			GhostEntity:SetRenderMode( RENDERMODE_TRANSALPHA )
 			GhostEntity:SetColor( Color(255, 255, 255, 150) )
-	
+
 			GhostEntity:SetAngles(Phys.Angle)
 			GhostEntity:SetPos(self:GetPos() + Phys.Pos - self.Offset)
 			self:SetAngles(self.EntAngle)
@@ -169,7 +169,7 @@ function ENT:DoSpawn( ply )
 	AngleOffset2:RotateAroundAxis(self:GetRight(),AngleOffset.p)
 	AngleOffset2:RotateAroundAxis(self:GetForward(),AngleOffset.r)*/
 
-	local Ents, Constrs = AdvDupe2.duplicator.Paste(ply, self.EntityTable, self.ConstraintTable, nil, nil, Vector(0,0,0), true) 
+	local Ents, Constrs = AdvDupe2.duplicator.Paste(ply, self.EntityTable, self.ConstraintTable, nil, nil, Vector(0,0,0), true)
 	local i = #self.UndoList+1
 	self.UndoList[i] = Ents
 
@@ -179,15 +179,15 @@ function ENT:DoSpawn( ply )
 		local phys
 		for k,ent in pairs(Ents)do
 			phys = ent:GetPhysicsObject()
-			if IsValid(phys) then 
+			if IsValid(phys) then
 				phys:Wake()
 				if(self.DisableGravity==1)then phys:EnableGravity(false) end
 				if(self.DisableDrag==1)then phys:EnableDrag(false) end
 				phys:EnableMotion(true)
 				if(ent.SetForce)then ent.SetForce(ent, ent.force, ent.mul) end
-				if(self.AddVelocity==1)then 
-					phys:SetVelocity( self:GetVelocity() ) 
-					phys:AddAngleVelocity( self:GetPhysicsObject():GetAngleVelocity() ) 
+				if(self.AddVelocity==1)then
+					phys:SetVelocity( self:GetVelocity() )
+					phys:AddAngleVelocity( self:GetPhysicsObject():GetAngleVelocity() )
 				end
 			end
 
@@ -196,7 +196,7 @@ function ENT:DoSpawn( ply )
 
 		undo.SetPlayer(ply)
 	undo.Finish()
-	
+
 	if(self.undo_delay>0)then
 		timer.Simple(self.undo_delay, function()
 			if(self.UndoList && self.UndoList[i])then
@@ -205,13 +205,13 @@ function ENT:DoSpawn( ply )
 						ent:Remove()
 					end
 				end
-			end	
+			end
 		end)
 	end
 end
 
 function ENT:DoUndo( ply )
-	
+
 	if(!self.UndoList || #self.UndoList == 0)then return end
 
 	local entities = self.UndoList[	#self.UndoList ]
@@ -261,17 +261,17 @@ function ENT:ShowOutput()
 end
 
 /*-----------------------------------------------------------------------*
- * Handler for spawn keypad input
- *-----------------------------------------------------------------------*/
+* Handler for spawn keypad input
+*-----------------------------------------------------------------------*/
 function SpawnContrSpawner( ply, ent )
 
 	if (!ent || !ent:IsValid()) then return end
 
 	local delay = ent:GetTable():GetCreationDelay()
-	
-	if(delay == 0) then 
+
+	if(delay == 0) then
 		ent:DoSpawn( ply )
-		return 
+		return
 	end
 
 	if(CurTime() < ent.LastSpawnTime)then return end
@@ -280,8 +280,8 @@ function SpawnContrSpawner( ply, ent )
 end
 
 /*-----------------------------------------------------------------------*
- * Handler for undo keypad input
- *-----------------------------------------------------------------------*/
+* Handler for undo keypad input
+*-----------------------------------------------------------------------*/
 function UndoContrSpawner( ply, ent )
 	if (!ent || !ent:IsValid()) then return end
 	ent:DoUndo( ply, true )


### PR DESCRIPTION
I'm tired of diff noise because my vs code trims all trailing whitespace from the file when editing AdvDupe2 code. This PR removes all trailing whitespace and converts the remaining spaces to tabs