### PR TITLE
add handling of duplicator.ConstraintType functions for BuildDupeInfo

### DIFF
--- a/lua/advdupe2/sv_misc.lua
+++ b/lua/advdupe2/sv_misc.lua
@@ -79,15 +79,20 @@ local function SavePositions( Constraint )
 	end
 end
 
-local function monitorConstraint(name)
-	local oldFunc = constraint[name]
-	constraint[name] = function(...)
+local function replaceConstraintFunction(oldFunc)
+	return function(...)
 		local Constraint, b, c = oldFunc(...)
 		if Constraint and Constraint:IsValid() then
 			SavePositions(Constraint)
 		end
 		return Constraint, b, c
 	end
+end
+
+local function monitorConstraint(name)
+	local desc			= duplicator.ConstraintType[name]
+	desc.Func			= replaceConstraintFunction(desc.Func)
+	constraint[name]	= replaceConstraintFunction(constraint[name])
 end
 monitorConstraint("AdvBallsocket")
 monitorConstraint("Axis")


### PR DESCRIPTION
Fix for issue https://github.com/wiremod/advdupe2/issues/539

Adds creation of BuildDupeInfo when a constraint is spawned by the vanilla duplicator.