### PR TITLE
Fix lua error

### DIFF
--- a/lua/entities/gmod_contr_spawner/init.lua
+++ b/lua/entities/gmod_contr_spawner/init.lua
@@ -189,7 +189,7 @@ function ENT:DoSpawn( ply )
 					phys:SetVelocity( self:GetVelocity() )
 					local self_phys = self:GetPhysicsObject()
 
-					if IsValid( phys ) then
+					if IsValid( self_phys ) then
 						phys:AddAngleVelocity( self_phys:GetAngleVelocity() )
 					end
 				end

--- a/lua/entities/gmod_contr_spawner/init.lua
+++ b/lua/entities/gmod_contr_spawner/init.lua
@@ -187,7 +187,11 @@ function ENT:DoSpawn( ply )
 				if(ent.SetForce)then ent.SetForce(ent, ent.force, ent.mul) end
 				if(self.AddVelocity==1)then
 					phys:SetVelocity( self:GetVelocity() )
-					phys:AddAngleVelocity( self:GetPhysicsObject():GetAngleVelocity() )
+					local self_phys = self:GetPhysicsObject()
+
+					if IsValid( phys ) then
+						phys:AddAngleVelocity( self_phys:GetAngleVelocity() )
+					end
 				end
 			end
 


### PR DESCRIPTION
Fixes:
```
- addons/advdupe2/lua/entities/gmod_contr_spawner/init.lua:190: Tried to use a NULL physics object!
1. GetAngleVelocity - [C]:-1
 2. DoSpawn - addons/advdupe2/lua/entities/gmod_contr_spawner/init.lua:190
  3. <unknown> - addons/advdupe2/lua/entities/gmod_contr_spawner/init.lua:237
   4. ProtectedCall - [C]:-1
    5. TriggerInput - addons/wire/lua/wire/server/wirelib.lua:87
     6. TriggerOutput - addons/wire/lua/wire/server/wirelib.lua:732
      7. <unknown> - addons/wire/lua/entities/gmod_wire_pod.lua:373
       8. Run - addons/hook-library/lua/includes/modules/hook.lua:348
        9. <unknown> - addons/wire/lua/wire/wireshared.lua:1198
         10. <unknown> - addons/hook-library/lua/includes/modules/hook.lua:348
```