### PR TITLE
Fix ModelScale regression in MakeProp

### DIFF
--- a/lua/advdupe2/sv_clipboard.lua
+++ b/lua/advdupe2/sv_clipboard.lua
@@ -906,6 +906,7 @@ local function MakeProp(ply, pos, ang, model, physicsobject, data)
 
 	if ply then prop:SetCreator(ply) end
 	prop:Spawn()
+	prop:Activate()
 
 	DoGenericPhysics(prop, data, ply)
 


### PR DESCRIPTION
Adds "prop:Activate()" back, removed in https://github.com/wiremod/advdupe2/pull/522: https://github.com/wiremod/advdupe2/commit/bb6f836416c7954ec4826161f636fed585e7df7f#diff-acb623eeeb53481b1e82274b16a2d0d4413abd6b7cf5f0b67f18950f566bdf54L907.

This fixes incorrect collisions of ModelScale'd props. [Entity:Activate](https://wiki.facepunch.com/gmod/Entity:Activate) properly recreates physics object.